### PR TITLE
Add message for otp bypass

### DIFF
--- a/lib/rubygems/gemcutter_utilities.rb
+++ b/lib/rubygems/gemcutter_utilities.rb
@@ -274,7 +274,7 @@ module Gem::GemcutterUtilities
     thread.report_on_exception = false
 
     url_with_port = "#{webauthn_url}?port=#{port}"
-    say "You have enabled multi-factor authentication. Please visit #{url_with_port} to authenticate via security device."
+    say "You have enabled multi-factor authentication. Please visit #{url_with_port} to authenticate via security device. If you can't verify using WebAuthn but have OTP enabled, you can re-run the gem signin command with the `--otp [your_code]` option."
 
     thread.join
     if error = thread[:error]

--- a/test/rubygems/test_gem_commands_owner_command.rb
+++ b/test/rubygems/test_gem_commands_owner_command.rb
@@ -385,7 +385,7 @@ EOF
     end
 
     url_with_port = "#{webauthn_verification_url}?port=#{port}"
-    assert_match "You have enabled multi-factor authentication. Please visit #{url_with_port} to authenticate via security device.", @stub_ui.output
+    assert_match "You have enabled multi-factor authentication. Please visit #{url_with_port} to authenticate via security device. If you can't verify using WebAuthn but have OTP enabled, you can re-run the gem signin command with the `--otp [your_code]` option.", @stub_ui.output
     assert_match "You are verified with a security device. You may close the browser window.", @stub_ui.output
     assert_equal "Uvh6T57tkWuUnWYo", @stub_fetcher.last_request["OTP"]
     assert_match response_success, @stub_ui.output
@@ -416,7 +416,7 @@ EOF
     end
 
     url_with_port = "#{webauthn_verification_url}?port=#{port}"
-    assert_match "You have enabled multi-factor authentication. Please visit #{url_with_port} to authenticate via security device.", @stub_ui.output
+    assert_match "You have enabled multi-factor authentication. Please visit #{url_with_port} to authenticate via security device. If you can't verify using WebAuthn but have OTP enabled, you can re-run the gem signin command with the `--otp [your_code]` option.", @stub_ui.output
     assert_match "ERROR:  Security device verification failed: Something went wrong", @stub_ui.error
     refute_match "You are verified with a security device. You may close the browser window.", @stub_ui.output
     refute_match response_success, @stub_ui.output

--- a/test/rubygems/test_gem_commands_push_command.rb
+++ b/test/rubygems/test_gem_commands_push_command.rb
@@ -448,7 +448,7 @@ class TestGemCommandsPushCommand < Gem::TestCase
     end
 
     url_with_port = "#{webauthn_verification_url}?port=#{port}"
-    assert_match "You have enabled multi-factor authentication. Please visit #{url_with_port} to authenticate via security device.", @ui.output
+    assert_match "You have enabled multi-factor authentication. Please visit #{url_with_port} to authenticate via security device. If you can't verify using WebAuthn but have OTP enabled, you can re-run the gem signin command with the `--otp [your_code]` option.", @ui.output
     assert_match "You are verified with a security device. You may close the browser window.", @ui.output
     assert_equal "Uvh6T57tkWuUnWYo", @fetcher.last_request["OTP"]
     assert_match response_success, @ui.output
@@ -482,7 +482,7 @@ class TestGemCommandsPushCommand < Gem::TestCase
     assert_equal 1, error.exit_code
 
     url_with_port = "#{webauthn_verification_url}?port=#{port}"
-    assert_match "You have enabled multi-factor authentication. Please visit #{url_with_port} to authenticate via security device.", @ui.output
+    assert_match "You have enabled multi-factor authentication. Please visit #{url_with_port} to authenticate via security device. If you can't verify using WebAuthn but have OTP enabled, you can re-run the gem signin command with the `--otp [your_code]` option.", @ui.output
     assert_match "ERROR:  Security device verification failed: Something went wrong", @ui.error
     refute_match "You are verified with a security device. You may close the browser window.", @ui.output
     refute_match response_success, @ui.output

--- a/test/rubygems/test_gem_commands_yank_command.rb
+++ b/test/rubygems/test_gem_commands_yank_command.rb
@@ -145,7 +145,7 @@ class TestGemCommandsYankCommand < Gem::TestCase
 
     url_with_port = "#{webauthn_verification_url}?port=#{port}"
     assert_match %r{Yanking gem from http://example}, @ui.output
-    assert_match "You have enabled multi-factor authentication. Please visit #{url_with_port} to authenticate via security device.", @ui.output
+    assert_match "You have enabled multi-factor authentication. Please visit #{url_with_port} to authenticate via security device. If you can't verify using WebAuthn but have OTP enabled, you can re-run the gem signin command with the `--otp [your_code]` option.", @ui.output
     assert_match "You are verified with a security device. You may close the browser window.", @ui.output
     assert_equal "Uvh6T57tkWuUnWYo", @fetcher.last_request["OTP"]
     assert_match %r{Successfully yanked}, @ui.output
@@ -185,7 +185,7 @@ class TestGemCommandsYankCommand < Gem::TestCase
 
     url_with_port = "#{webauthn_verification_url}?port=#{port}"
     assert_match %r{Yanking gem from http://example}, @ui.output
-    assert_match "You have enabled multi-factor authentication. Please visit #{url_with_port} to authenticate via security device.", @ui.output
+    assert_match "You have enabled multi-factor authentication. Please visit #{url_with_port} to authenticate via security device. If you can't verify using WebAuthn but have OTP enabled, you can re-run the gem signin command with the `--otp [your_code]` option.", @ui.output
     assert_match "ERROR:  Security device verification failed: Something went wrong", @ui.error
     refute_match "You are verified with a security device. You may close the browser window.", @ui.output
     refute_match %r{Successfully yanked}, @ui.output

--- a/test/rubygems/test_gem_gemcutter_utilities.rb
+++ b/test/rubygems/test_gem_gemcutter_utilities.rb
@@ -253,7 +253,7 @@ class TestGemGemcutterUtilities < Gem::TestCase
     end
 
     url_with_port = "#{webauthn_verification_url}?port=#{port}"
-    assert_match "You have enabled multi-factor authentication. Please visit #{url_with_port} to authenticate via security device.", @sign_in_ui.output
+    assert_match "You have enabled multi-factor authentication. Please visit #{url_with_port} to authenticate via security device. If you can't verify using WebAuthn but have OTP enabled, you can re-run the gem signin command with the `--otp [your_code]` option.", @sign_in_ui.output
     assert_match "You are verified with a security device. You may close the browser window.", @sign_in_ui.output
     assert_equal "Uvh6T57tkWuUnWYo", @fetcher.last_request["OTP"]
   end
@@ -285,7 +285,7 @@ class TestGemGemcutterUtilities < Gem::TestCase
     assert_equal 1, error.exit_code
 
     url_with_port = "#{webauthn_verification_url}?port=#{port}"
-    assert_match "You have enabled multi-factor authentication. Please visit #{url_with_port} to authenticate via security device.", @sign_in_ui.output
+    assert_match "You have enabled multi-factor authentication. Please visit #{url_with_port} to authenticate via security device. If you can't verify using WebAuthn but have OTP enabled, you can re-run the gem signin command with the `--otp [your_code]` option.", @sign_in_ui.output
     assert_match "ERROR:  Security device verification failed: Something went wrong", @sign_in_ui.error
     refute_match "You are verified with a security device. You may close the browser window.", @sign_in_ui.output
     refute_match "Signed in with API key:", @sign_in_ui.output


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?
As described in https://github.com/Shopify/ruby-dependency-security/issues/258, we want a fallback for OTP if OTP and WebAuthN are enabled. By default WebAuthN is chosen. 

## What is your fix for the problem, implemented in this PR?
After reviewing the `gem signin` flow, we already offer an OTP option. Also, as discussed in the issue linked above, the chosen approach for this was to only offer webauthn, and offer OTP as a fallback, which would be a flag. So, no new logic needed to be introduced. Instead, I added a line to the WebAuthN logic to ensure the user knows they have this option.

<img width="746" alt="Screenshot 2023-03-20 at 2 51 11 PM" src="https://user-images.githubusercontent.com/71022385/226438013-51bdd9d9-c65a-45d4-bdc8-20ba2c6cdd9e.png">


## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
