### PR TITLE
Ensure api_key is sent if basic auth not provided on webauthn_verification_url

### DIFF
--- a/lib/rubygems/gemcutter_utilities.rb
+++ b/lib/rubygems/gemcutter_utilities.rb
@@ -287,10 +287,10 @@ module Gem::GemcutterUtilities
 
   def webauthn_verification_url(credentials)
     response = rubygems_api_request(:post, "api/v1/webauthn_verification") do |request|
-      if credentials
-        request.basic_auth credentials[:email], credentials[:password]
-      else
+      if credentials.empty?
         request.add_field "Authorization", api_key
+      else
+        request.basic_auth credentials[:email], credentials[:password]
       end
     end
     response.is_a?(Net::HTTPSuccess) ? response.body : nil

--- a/test/rubygems/test_gem_commands_owner_command.rb
+++ b/test/rubygems/test_gem_commands_owner_command.rb
@@ -417,6 +417,8 @@ EOF
     end
 
     url_with_port = "#{webauthn_verification_url}?port=#{port}"
+
+    assert_match @stub_fetcher.last_request["Authorization"], Gem.configuration.rubygems_api_key
     assert_match "You have enabled multi-factor authentication. Please visit #{url_with_port} to authenticate via security device. If you can't verify using WebAuthn but have OTP enabled, you can re-run the gem signin command with the `--otp [your_code]` option.", @stub_ui.output
     assert_match "ERROR:  Security device verification failed: Something went wrong", @stub_ui.error
     refute_match "You are verified with a security device. You may close the browser window.", @stub_ui.output

--- a/test/rubygems/test_gem_commands_push_command.rb
+++ b/test/rubygems/test_gem_commands_push_command.rb
@@ -482,6 +482,7 @@ class TestGemCommandsPushCommand < Gem::TestCase
     end
     assert_equal 1, error.exit_code
 
+    assert_match @fetcher.last_request["Authorization"], Gem.configuration.rubygems_api_key
     url_with_port = "#{webauthn_verification_url}?port=#{port}"
     assert_match "You have enabled multi-factor authentication. Please visit #{url_with_port} to authenticate via security device. If you can't verify using WebAuthn but have OTP enabled, you can re-run the gem signin command with the `--otp [your_code]` option.", @ui.output
     assert_match "ERROR:  Security device verification failed: Something went wrong", @ui.error

--- a/test/rubygems/test_gem_commands_yank_command.rb
+++ b/test/rubygems/test_gem_commands_yank_command.rb
@@ -185,6 +185,8 @@ class TestGemCommandsYankCommand < Gem::TestCase
     assert_equal 1, error.exit_code
 
     url_with_port = "#{webauthn_verification_url}?port=#{port}"
+
+    assert_match @fetcher.last_request["Authorization"], Gem.configuration.rubygems_api_key
     assert_match %r{Yanking gem from http://example}, @ui.output
     assert_match "You have enabled multi-factor authentication. Please visit #{url_with_port} to authenticate via security device. If you can't verify using WebAuthn but have OTP enabled, you can re-run the gem signin command with the `--otp [your_code]` option.", @ui.output
     assert_match "ERROR:  Security device verification failed: Something went wrong", @ui.error


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

On `gem push`, `gem yank`, and `gem owner` commands, users were not being given a webauthn url, they were instead prompted to use OTP, even if webauthn was enabled. 

## What is your fix for the problem, implemented in this PR?

This ensures that if no basic auth sign in credentials are given, we send the api_key for sign in instead. That way, the webauthn_verification_url has the correct signed in user and can send the correct result. 

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
