### PR TITLE
Introduce a priority queue:

### DIFF
--- a/bundler/lib/bundler/installer/parallel_installer.rb
+++ b/bundler/lib/bundler/installer/parallel_installer.rb
@@ -24,6 +24,10 @@ module Bundler
         state == :enqueued
       end
 
+      def enqueue_with_priority?
+        state == :installable && spec.extensions.any?
+      end
+
       def failed?
         state == :failed
       end
@@ -194,7 +198,7 @@ module Bundler
         spec.state = :installable
       end
 
-      worker_pool.enq(spec)
+      worker_pool.enq(spec, priority: spec.enqueue_with_priority?)
     end
 
     def finished_installing?
@@ -231,6 +235,7 @@ module Bundler
     # previously installed specifications. We continue until all specs
     # are installed.
     def enqueue_specs(installed_specs)
+      $S = 1
       @specs.each do |spec|
         if spec.installed?
           installed_specs[spec.name] = true

--- a/bundler/lib/bundler/worker.rb
+++ b/bundler/lib/bundler/worker.rb
@@ -22,6 +22,7 @@ module Bundler
     def initialize(size, name, func)
       @name = name
       @request_queue = Thread::Queue.new
+      @request_queue_with_priority = Thread::Queue.new
       @response_queue = Thread::Queue.new
       @func = func
       @size = size
@@ -32,9 +33,10 @@ module Bundler
     # Enqueue a request to be executed in the worker pool
     #
     # @param obj [String] mostly it is name of spec that should be downloaded
-    def enq(obj)
+    def enq(obj, priority: false)
+      queue = priority ? @request_queue_with_priority : @request_queue
       create_threads unless @threads
-      @request_queue.enq obj
+      queue.enq obj
     end
 
     # Retrieves results of job function being executed in worker pool
@@ -52,7 +54,13 @@ module Bundler
 
     def process_queue(i)
       loop do
-        obj = @request_queue.deq
+        obj = begin
+          @request_queue_with_priority.deq(true)
+        rescue ThreadError
+          @request_queue.deq(false, timeout: 0.05)
+        end
+
+        next if obj.nil?
         break if obj.equal? POISON
         @response_queue.enq apply_func(obj, i)
       end

--- a/bundler/spec/bundler/installer/parallel_installer_spec.rb
+++ b/bundler/spec/bundler/installer/parallel_installer_spec.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+require "bundler/installer/parallel_installer"
+require "bundler/rubygems_gem_installer"
+require "rubygems/remote_fetcher"
+require "bundler"
+
+RSpec.describe Bundler::ParallelInstaller do
+  describe "connect to make jobserver" do
+    before do
+      require "support/artifice/compact_index"
+
+      @previous_client = Gem::Request::ConnectionPools.client
+      Gem::Request::ConnectionPools.client = Gem::Net::HTTP
+      Gem::RemoteFetcher.fetcher.close_all
+
+      build_repo2 do
+        build_gem "gem_with_extension", &:add_c_extension
+        build_gem "gem_without_extension"
+      end
+
+      gemfile <<~G
+        source "https://gem.repo2"
+
+        gem "gem_with_extension"
+        gem "gem_without_extension"
+      G
+      lockfile <<~L
+        GEM
+          remote: https://gem.repo2/
+          specs:
+            gem_with_extension (1.0)
+            gem_without_extension (1.0)
+
+        DEPENDENCIES
+          gem_with_extension
+          gem_without_extension
+      L
+
+      @old_ui = Bundler.ui
+      Bundler.ui = Bundler::UI::Silent.new
+    end
+
+    after do
+      Bundler.ui = @old_ui
+      Gem::Request::ConnectionPools.client = @previous_client
+      Artifice.deactivate
+    end
+
+    let(:definition) do
+      allow(Bundler).to receive(:root) { bundled_app }
+
+      definition = Bundler::Definition.build(bundled_app.join("Gemfile"), bundled_app.join("Gemfile.lock"), false)
+      definition.tap(&:setup_domain!)
+    end
+    let(:installer) { Bundler::Installer.new(bundled_app, definition) }
+
+    it "takes all available slots" do
+      parallel_installer = Bundler::ParallelInstaller.new(installer, definition.specs, 2, false, true)
+      worker_pool = parallel_installer.send(:worker_pool)
+      expected = 6 # Enqueue to download bundler and the 2 gems. Enqueue to install Bundler and the 2 gems.
+
+      expect(worker_pool).to receive(:enq).exactly(expected).times.and_wrap_original do |original_enq, spec, opts|
+        unless opts.nil? # Enqueued for download, no priority
+          if spec.name == "gem_with_extension"
+            expect(opts).to eq({ priority: true })
+          else
+            expect(opts).to eq({ priority: false })
+          end
+        end
+
+        original_enq.call(spec, **opts)
+      end
+
+      parallel_installer.call
+    end
+  end
+end

--- a/bundler/spec/bundler/worker_spec.rb
+++ b/bundler/spec/bundler/worker_spec.rb
@@ -20,6 +20,26 @@ RSpec.describe Bundler::Worker do
     end
   end
 
+  describe "priority queue" do
+    it "process elements from the priority queue first" do
+      processed_elements = []
+
+      function = proc do |element, _|
+        processed_elements << element
+      end
+
+      worker = described_class.new(1, "Spec Worker", function)
+      worker.instance_variable_set(:@threads, []) # Prevent the enqueueing from starting work.
+      worker.enq("Normal element")
+      worker.enq("Priority element", priority: true)
+      worker.send(:create_threads)
+
+      worker.stop
+
+      expect(processed_elements).to eq(["Priority element", "Normal element"])
+    end
+  end
+
   describe "handling interrupts" do
     let(:status) do
       pid = Process.fork do

--- a/bundler/spec/support/windows_tag_group.rb
+++ b/bundler/spec/support/windows_tag_group.rb
@@ -137,6 +137,7 @@ module Spec
         "spec/bundler/build_metadata_spec.rb",
         "spec/bundler/current_ruby_spec.rb",
         "spec/bundler/installer/gem_installer_spec.rb",
+        "spec/bundler/installer/parallel_installer_spec.rb",
         "spec/bundler/cli_common_spec.rb",
         "spec/bundler/ci_detector_spec.rb",
       ],


### PR DESCRIPTION
> [!NOTE]
> This PR is stacked on top of https://github.com/ruby/rubygems/pull/9381

## What was the end-user or developer problem that led to this PR?

In https://github.com/ruby/rubygems/pull/9381, I explained the issue about the "tail latency".

TL;DR When a gem with a native extensions is downloaded, the sooner we starts compiling, the sooner it gets installed. If a gem with a native extensions ends up at the end of the queue, the longer `bundle install` becomes.

### Before (Benchmark recorded from #9381)

<img width="1509" height="475" alt="tail-before" src="https://github.com/user-attachments/assets/81a309f6-4319-4c94-9052-296a9f9d8b8e" />

### After

<img width="1505" height="493" alt="tail-after" src="https://github.com/user-attachments/assets/1cda6c60-487d-4852-9d57-f6005ab640b5" />


## What is your fix for the problem, implemented in this PR?

I'd like to introduce a simple queue with priority. When a gem is downloaded, we check whether that gem has a native extension and if its dependencies are installed. If both conditions are met, we add the gem in the priority queue to be picked up as quickly as possible.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/ruby/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/ruby/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/ruby/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
