### PR TITLE
Content addressable gems poc

### DIFF
--- a/bundler/lib/bundler/compact_index_client.rb
+++ b/bundler/lib/bundler/compact_index_client.rb
@@ -63,38 +63,24 @@ module Bundler
 
     attr_reader :api_version
 
-    # Determine, once per source, the newest compact index API version this
-    # source actually serves. Newer clients prefer v2 (`/v2/versions`,
-    # `/v2/info`); sources that only speak v1 answer the probe with a 404, so
-    # we transparently downgrade. The result is cached on disk so subsequent
-    # runs skip the probe (and so a v1-only source isn't re-probed every time).
+    # Determine the newest compact index API version this source actually
+    # serves. Newer clients prefer v2 (`/v2/versions`, `/v2/info`); sources that
+    # only speak v1 answer the probe with a 404, so we transparently downgrade.
+    #
+    # We re-probe on every resolve rather than trusting a cached decision
+    # forever, so a source that later adds v2 support is picked up. This is
+    # consistent with how `versions`/`info` are revalidated every run: the
+    # probe's `versions` fetch is an ETag-conditional request, so for the
+    # version a source actually serves it costs a cheap 304 when nothing
+    # changed. The persisted marker is kept only as an offline fallback (see
+    # #probe_api_version!).
     #
     # Only meaningful with a fetcher; read-only clients stay on the version
     # they were constructed with.
     def negotiate_api_version!
       return @api_version unless @fetcher
 
-      cached = persisted_api_version
-      if cached
-        use_api_version(cached) unless cached == @api_version
-        return @api_version
-      end
-
-      SUPPORTED_API_VERSIONS.each do |version|
-        use_api_version(version)
-        begin
-          versions # probe: fetches /vN/versions (or /versions for v1)
-          persist_api_version(version)
-          break
-        rescue Bundler::Fetcher::FallbackError
-          # This source doesn't serve this API version (404). Try the next
-          # lower one; v1 is unprefixed and always exists for a compact index.
-          next unless version == SUPPORTED_API_VERSIONS.last
-          raise
-        end
-      end
-
-      @api_version
+      probe_api_version!(fallback: persisted_api_version)
     end
 
     def names
@@ -133,6 +119,36 @@ module Bundler
     end
 
     private
+
+    # Probe the source over the wire, newest version first, and persist the
+    # result. The `versions` call uses ETag-conditional requests, so probing the
+    # version a source serves is cheap on a warm cache (304 Not Modified).
+    #
+    # If a usable `fallback` version is supplied and the probe fails for any
+    # reason other than a clean downgrade (e.g. the network is unreachable),
+    # keep using the fallback rather than failing the whole resolve -- this is
+    # what lets `bundle install` work offline against a warm cache.
+    def probe_api_version!(fallback: nil)
+      SUPPORTED_API_VERSIONS.each do |version|
+        use_api_version(version)
+        begin
+          versions # probe: fetches /vN/versions (or /versions for v1)
+          persist_api_version(version)
+          return @api_version
+        rescue Bundler::Fetcher::FallbackError
+          # This source doesn't serve this API version (404). Try the next
+          # lower one; v1 is unprefixed and always exists for a compact index.
+          next unless version == SUPPORTED_API_VERSIONS.last
+          raise
+        end
+      end
+
+      @api_version
+    rescue StandardError
+      raise unless fallback
+      use_api_version(fallback)
+      @api_version
+    end
 
     def use_api_version(version)
       version = 1 unless SUPPORTED_API_VERSIONS.include?(version)

--- a/bundler/lib/bundler/compact_index_client.rb
+++ b/bundler/lib/bundler/compact_index_client.rb
@@ -30,6 +30,12 @@ module Bundler
     SUPPORTED_DIGESTS = { "sha-256" => :SHA256 }.freeze
     DEBUG_MUTEX = Thread::Mutex.new
 
+    # API versions this client understands, newest first. v2 adds the
+    # content-addressable ("skinny") binary namespace under `/v2/`.
+    SUPPORTED_API_VERSIONS = [2, 1].freeze
+    API_VERSION_MARKER = "api_version"
+
+
     # info returns an Array of INFO Arrays. Each INFO Array has the following indices:
     INFO_NAME = 0
     INFO_VERSION = 1
@@ -49,9 +55,46 @@ module Bundler
     require_relative "compact_index_client/parser"
     require_relative "compact_index_client/updater"
 
-    def initialize(directory, fetcher = nil)
-      @cache = Cache.new(directory, fetcher)
-      @parser = Parser.new(@cache)
+    def initialize(directory, fetcher = nil, api_version: 1)
+      @directory = Pathname.new(directory).expand_path
+      @fetcher = fetcher
+      use_api_version(api_version)
+    end
+
+    attr_reader :api_version
+
+    # Determine, once per source, the newest compact index API version this
+    # source actually serves. Newer clients prefer v2 (`/v2/versions`,
+    # `/v2/info`); sources that only speak v1 answer the probe with a 404, so
+    # we transparently downgrade. The result is cached on disk so subsequent
+    # runs skip the probe (and so a v1-only source isn't re-probed every time).
+    #
+    # Only meaningful with a fetcher; read-only clients stay on the version
+    # they were constructed with.
+    def negotiate_api_version!
+      return @api_version unless @fetcher
+
+      cached = persisted_api_version
+      if cached
+        use_api_version(cached) unless cached == @api_version
+        return @api_version
+      end
+
+      SUPPORTED_API_VERSIONS.each do |version|
+        use_api_version(version)
+        begin
+          versions # probe: fetches /vN/versions (or /versions for v1)
+          persist_api_version(version)
+          break
+        rescue Bundler::Fetcher::FallbackError
+          # This source doesn't serve this API version (404). Try the next
+          # lower one; v1 is unprefixed and always exists for a compact index.
+          next unless version == SUPPORTED_API_VERSIONS.last
+          raise
+        end
+      end
+
+      @api_version
     end
 
     def names
@@ -87,6 +130,34 @@ module Bundler
     def reset!
       Bundler::CompactIndexClient.debug { "reset!" }
       @cache.reset!
+    end
+
+    private
+
+    def use_api_version(version)
+      version = 1 unless SUPPORTED_API_VERSIONS.include?(version)
+      @api_version = version
+      @cache = Cache.new(@directory, @fetcher, api_version: version)
+      @parser = Parser.new(@cache)
+    end
+
+    def api_version_marker_path
+      @directory.join(API_VERSION_MARKER)
+    end
+
+    def persisted_api_version
+      path = api_version_marker_path
+      return unless path.file?
+      version = path.read.to_i
+      SUPPORTED_API_VERSIONS.include?(version) ? version : nil
+    rescue StandardError
+      nil
+    end
+
+    def persist_api_version(version)
+      api_version_marker_path.write(version.to_s)
+    rescue StandardError
+      nil
     end
   end
 end

--- a/bundler/lib/bundler/compact_index_client/cache.rb
+++ b/bundler/lib/bundler/compact_index_client/cache.rb
@@ -7,15 +7,22 @@ module Bundler
     class Cache
       attr_reader :directory
 
-      def initialize(directory, fetcher = nil)
+      def initialize(directory, fetcher = nil, api_version: 1)
         @directory = Pathname.new(directory).expand_path
         @updater = Updater.new(fetcher) if fetcher
         @mutex = Thread::Mutex.new
         @endpoints = Set.new
+        @api_version = api_version
 
-        @info_root = mkdir("info")
-        @special_characters_info_root = mkdir("info-special-characters")
-        @info_etag_root = mkdir("info-etags")
+        # `names` is shared across API versions. `versions` and `info` differ
+        # between v1 and v2 (different info checksums and content-addressable
+        # version tokens), so their cache files live under a per-version
+        # subdirectory to avoid collisions with a previously-cached v1.
+        @versioned_directory = api_version >= 2 ? mkdir(@directory.join("v#{api_version}")) : @directory
+
+        @info_root = mkdir(@versioned_directory.join("info"))
+        @special_characters_info_root = mkdir(@versioned_directory.join("info-special-characters"))
+        @info_etag_root = mkdir(@versioned_directory.join("info-etags"))
       end
 
       def names
@@ -23,14 +30,14 @@ module Bundler
       end
 
       def versions
-        fetch("versions", versions_path, versions_etag_path)
+        fetch("#{remote_prefix}versions", versions_path, versions_etag_path)
       end
 
       def info(name, remote_checksum = nil)
         path = info_path(name)
 
         if remote_checksum && remote_checksum != SharedHelpers.checksum_for_file(path, :MD5)
-          fetch("info/#{name}", path, info_etag_path(name))
+          fetch("#{remote_prefix}info/#{name}", path, info_etag_path(name))
         else
           Bundler::CompactIndexClient.debug { "update skipped info/#{name} (#{remote_checksum ? "versions index checksum is nil" : "versions index checksum matches local"})" }
           read(path)
@@ -43,10 +50,17 @@ module Bundler
 
       private
 
+      # v1 paths are unprefixed for backwards compatibility; v2+ are served under
+      # a `v<N>/` path namespace so old clients never see content-addressable
+      # entries.
+      def remote_prefix
+        @api_version >= 2 ? "v#{@api_version}/" : ""
+      end
+
       def names_path = directory.join("names")
       def names_etag_path = directory.join("names.etag")
-      def versions_path = directory.join("versions")
-      def versions_etag_path = directory.join("versions.etag")
+      def versions_path = @versioned_directory.join("versions")
+      def versions_etag_path = @versioned_directory.join("versions.etag")
 
       def info_path(name)
         name = name.to_s
@@ -64,12 +78,11 @@ module Bundler
         @info_etag_root.join("#{name}-#{SharedHelpers.digest(:MD5).hexdigest(name).downcase}")
       end
 
-      def mkdir(name)
-        directory.join(name).tap do |dir|
-          SharedHelpers.filesystem_access(dir) do
-            FileUtils.mkdir_p(dir)
-          end
+      def mkdir(dir)
+        SharedHelpers.filesystem_access(dir) do
+          FileUtils.mkdir_p(dir)
         end
+        dir
       end
 
       def fetch(remote_path, path, etag_path)

--- a/bundler/lib/bundler/endpoint_specification.rb
+++ b/bundler/lib/bundler/endpoint_specification.rb
@@ -5,7 +5,7 @@ module Bundler
   class EndpointSpecification < Gem::Specification
     include MatchRemoteMetadata
 
-    attr_reader :name, :version, :platform, :checksum, :created_at
+    attr_reader :name, :version, :platform, :checksum, :created_at, :real_platform
     attr_writer :dependencies
     attr_accessor :remote, :locked_platform
 
@@ -21,11 +21,30 @@ module Bundler
       @loaded_from          = nil
       @remote_specification = nil
       @locked_platform = nil
+      @real_platform = nil
 
       parse_metadata(metadata)
     end
 
+    # A content-addressable ("skinny") binary: the version token carries a SHA
+    # prefix instead of a platform, and the real platform is supplied via the
+    # compact index `platform:` requirement.
+    def content_addressable?
+      !@real_platform.nil?
+    end
+
+    # For content-addressable specs, platform matching must use the real
+    # platform from metadata, not the SHA prefix stored in @platform.
+    def installable_on_platform?(target_platform)
+      return super unless content_addressable?
+
+      target_platform.nil? ||
+        target_platform == Gem::Platform::RUBY ||
+        @real_platform === Gem::Platform.new(target_platform)
+    end
+
     def insecurely_materialized?
+      return false if content_addressable?
       @locked_platform.to_s != @platform.to_s
     end
 
@@ -162,6 +181,10 @@ module Bundler
           @required_rubygems_version = Gem::Requirement.new(v)
         when "ruby"
           @required_ruby_version = Gem::Requirement.new(v)
+        when "platform"
+          # e.g. v == ["= x86_64-linux-musl"]; strip the requirement operator.
+          platform_string = Array(v).last.to_s.sub(/\A\s*=?\s*/, "")
+          @real_platform = Gem::Platform.new(platform_string) unless platform_string.empty?
         when "created_at"
           value = v.is_a?(Array) ? v.last : v
           if value.is_a?(String)

--- a/bundler/lib/bundler/fetcher/compact_index.rb
+++ b/bundler/lib/bundler/fetcher/compact_index.rb
@@ -68,7 +68,11 @@ module Bundler
       def compact_index_client
         @compact_index_client ||=
           SharedHelpers.filesystem_access(cache_path) do
-            CompactIndexClient.new(cache_path, client_fetcher)
+            client = CompactIndexClient.new(cache_path, client_fetcher)
+            # Negotiate v1/v2 once per source: prefer the content-addressable v2
+            # index, transparently downgrading to v1 for sources that 404 it.
+            client.negotiate_api_version!
+            client
           end
       end
 

--- a/bundler/lib/bundler/lazy_specification.rb
+++ b/bundler/lib/bundler/lazy_specification.rb
@@ -158,6 +158,17 @@ module Bundler
 
       if use_exact_resolved_specifications?
         spec = materialize(self) {|specs| choose_compatible(specs, fallback_to_non_installable: false) }
+
+        # The exact locked full_name wasn't found in the index (materialize returns
+        # self). This happens for content-addressable gems: the installed full_name
+        # is name-version-<sha>, while the lockfile pins the portable
+        # name-version-platform. Retry by name+version and let platform/ruby
+        # selection pick the right binary.
+        if spec.equal?(self)
+          by_name = materialize([name, version]) {|specs| resolve_best_platform(specs) }
+          return by_name unless by_name.nil? || by_name.equal?(self)
+        end
+
         return spec if spec
 
         # Exact spec is incompatible; in frozen mode, try to find a compatible platform variant

--- a/bundler/lib/bundler/lazy_specification.rb
+++ b/bundler/lib/bundler/lazy_specification.rb
@@ -9,7 +9,7 @@ module Bundler
     include ForcePlatform
 
     attr_reader :name, :version, :platform, :materialization
-    attr_accessor :source, :remote, :force_ruby_platform, :dependencies, :required_ruby_version, :required_rubygems_version, :overrides
+    attr_accessor :source, :remote, :force_ruby_platform, :dependencies, :required_ruby_version, :required_rubygems_version, :overrides, :real_platform, :content_address
 
     #
     # For backwards compatibility with existing lockfiles, if the most specific
@@ -31,7 +31,23 @@ module Bundler
       lazy_spec.required_ruby_version = s.required_ruby_version
       lazy_spec.required_rubygems_version = s.required_rubygems_version
       lazy_spec.overrides = s.overrides if s.is_a?(LazySpecification)
+      lazy_spec.real_platform = s.real_platform if s.respond_to?(:real_platform)
+      lazy_spec.content_address = s.content_address if s.respond_to?(:content_address)
       lazy_spec
+    end
+
+    def content_addressable?
+      !@real_platform.nil?
+    end
+
+    # Match using the real platform from metadata when content-addressable,
+    # since @platform holds the SHA prefix rather than a real platform.
+    def installable_on_platform?(target_platform)
+      return super unless content_addressable?
+
+      target_platform.nil? ||
+        target_platform == Gem::Platform::RUBY ||
+        @real_platform === Gem::Platform.new(target_platform)
     end
 
     def initialize(name, version, platform, source = nil, **materialization_options)
@@ -64,7 +80,9 @@ module Bundler
     end
 
     def full_name
-      @full_name ||= if platform == Gem::Platform::RUBY
+      @full_name ||= if @content_address
+        "#{@name}-#{@version}-#{@content_address}"
+      elsif platform == Gem::Platform::RUBY
         "#{@name}-#{@version}"
       else
         "#{@name}-#{@version}-#{platform}"

--- a/bundler/lib/bundler/match_platform.rb
+++ b/bundler/lib/bundler/match_platform.rb
@@ -26,7 +26,7 @@ module Bundler
       spec.respond_to?(:content_addressable?) && spec.content_addressable?
     end
 
-    # A skinny binary targets exactly one Ruby minor (e.g. `~> 3.2.0`). Those
+    # A skinny binary targets exactly one Ruby ABI (e.g. `~> 3.2.0`). Those
     # ranges are disjoint, so at most one skinny variant per (gem, version,
     # platform) is compatible with the running Ruby. Only a Ruby-compatible
     # skinny may displace the fat/ruby fallback.

--- a/bundler/lib/bundler/match_platform.rb
+++ b/bundler/lib/bundler/match_platform.rb
@@ -22,8 +22,33 @@ module Bundler
       Gem::Platform.sort_best_platform_match(matching, local)
     end
 
+    def self.content_addressable?(spec)
+      spec.respond_to?(:content_addressable?) && spec.content_addressable?
+    end
+
+    # A skinny binary targets exactly one Ruby minor (e.g. `~> 3.2.0`). Those
+    # ranges are disjoint, so at most one skinny variant per (gem, version,
+    # platform) is compatible with the running Ruby. Only a Ruby-compatible
+    # skinny may displace the fat/ruby fallback.
+    def self.usable_skinny?(spec)
+      return false unless content_addressable?(spec)
+
+      req = spec.required_ruby_version
+      req.nil? || req.none? || req.satisfied_by?(Gem.ruby_version)
+    end
+
     def self.select_all_platform_match(specs, platform, force_ruby: false, prefer_locked: false)
       matching = specs.select {|spec| spec.installable_on_platform?(force_ruby ? Gem::Platform::RUBY : platform) }
+
+      # Only choose the skinny (content-addressable) binary: when a skinny variant
+      # compatible with the running Ruby exists, prefer it exclusively. If no
+      # skinny matches this Ruby, keep the fat/ruby variants as a fallback so we
+      # never strand a usable binary. Because per-minor `~>` ranges are disjoint,
+      # at most one skinny qualifies — no skinny-vs-skinny tie-break is needed.
+      unless force_ruby
+        skinny = matching.select {|spec| usable_skinny?(spec) }
+        matching = skinny if skinny.any?
+      end
 
       specs.each(&:force_ruby_platform!) if force_ruby
 

--- a/bundler/lib/bundler/stub_specification.rb
+++ b/bundler/lib/bundler/stub_specification.rb
@@ -13,6 +13,19 @@ module Bundler
       false
     end
 
+    # Delegate to the underlying RubyGems stub so content-addressable binaries
+    # use their content-addressed name (name-version-<sha>), matching the install
+    # directory, rather than recomputing name-version-platform.
+    def full_name
+      stub.full_name
+    end
+
+    # The content address lives on the stub line, not in the gemspec body, so read
+    # it from the RubyGems stub rather than method_missing'ing to the full spec.
+    def content_address
+      stub.content_address
+    end
+
     attr_reader :checksum
     attr_accessor :stub, :ignored
 

--- a/dev/content-addressable-test/README.md
+++ b/dev/content-addressable-test/README.md
@@ -1,0 +1,92 @@
+# Content-addressable gems — manual end-to-end test
+
+Manual, native-macOS (darwin) tests for **content-addressable ("skinny")
+precompiled gems**. 
+
+A *skinny* binary is a platformed gem pinned to a single Ruby minor (here the
+demo's `required_ruby_version = "~> 3.3.0"`). These are built, named, installed,
+and resolved by **content address** — `name-version-<sha>`, where
+`<sha> = sha256(.gem)[0, 10]` — so multiple per-Ruby builds of the same
+version+platform can coexist and the right one is fetched at resolve time.
+
+## What's here
+
+| File | Purpose |
+| --- | --- |
+| `demo/` | A tiny native gem (`hola`) with a one-Ruby-minor `required_ruby_version`, so it builds as a skinny/content-addressable binary. |
+| `fake_compact_index.rb` | ~40-line, dependency-free threaded HTTP server that serves a directory as a compact index (`/v2/versions`, `/v2/info/<gem>`, `/gems/*.gem`). |
+| `test_local.sh` | Builds + installs the gem and exercises `bundle install --local`. |
+| `test_remote.sh` | Renders compact-index files, starts the fake server, and exercises a real remote `bundle install`. |
+
+## Requirements
+
+- A clean Ruby matching the demo's `~> 3.3.0` (default `/opt/rubies/3.3.5`).
+  Override with `RUBY_PREFIX=/opt/rubies/3.3.x`.
+- A C toolchain (Xcode CLT `clang`).
+- Network access on first run (to `gem install rake-compiler` from rubygems.org).
+
+The scripts auto-locate this rubygems checkout (two levels up) and load the
+**patched** RubyGems + Bundler from it.
+
+## How to run
+
+```bash
+cd dev/content-addressable-test
+./test_local.sh     # bundle install --local path
+./test_remote.sh    # remote path via the fake compact-index server
+```
+
+Each prints every step and ends with `ALL GOOD`.
+
+## What each test proves
+
+### `test_local.sh`
+1. `rake native gem` builds the skinny gem and renames it
+   `hola-1.0.0-<platform>.gem` → `hola-1.0.0-<sha>.gem` (in `Gem::Package.build`).
+2. `gem install --local` installs it under `gems/hola-1.0.0-<sha>/` and records
+   the sha in the stub line (`# stub: hola 1.0.0 <platform> lib <sha>`), so
+   `full_name` reconstructs the content-addressed name offline.
+3. `bundle install --local` resolves the content-addressed gem, including the
+   **lockfile round-trip**: the lock stays portable (`hola (1.0.0-<platform>)`),
+   and Bundler bridges that back to the on-disk `name-version-<sha>` gem.
+4. `bundle exec require "hola"` and `bundle list` work; re-running install is
+   idempotent.
+
+### `test_remote.sh`
+1. Builds the same gem and renders a compact index from it. The
+   content-addressable info line is:
+   ```
+   1.0.0-<sha> |checksum:<sha256-hex>,ruby:<req>,platform:<real-platform>
+   ```
+   - the version slot's "platform" = the **content address** (`<sha>`) → becomes
+     the gem's `full_name` and the download path `/gems/hola-1.0.0-<sha>.gem`;
+   - the `platform:` **metadata token** carries the real platform, used for
+     compatibility matching.
+2. Bundler probes `/v2/versions`, fetches `/v2/info/hola`, resolves
+   `hola 1.0.0 (<sha>)`, downloads `/gems/hola-1.0.0-<sha>.gem`, installs it, and
+   `require` works.
+
+## Gotchas (learned the hard way; encoded in the scripts)
+
+- **Use the released `rake-compiler`, not a dev branch.** Content-addressing
+  lives entirely in core `Gem::Package.build`; no rake-compiler patch is needed.
+- **Bundle must load the patched rubygems core**
+  (`RUBYOPT="--disable-gems -I<repo>/lib -rrubygems"`), not Ruby's built-in
+  rubygems. Otherwise the `<sha>` platform token parses to the bogus platform
+  `"unknown"` and the download 404s on `hola-1.0.0-unknown.gem`. (The patched
+  `lib/rubygems/platform.rb` preserves a 10-hex-char content address verbatim.)
+- **Put the build Ruby first on `PATH`** so `bundle exec ruby` matches the build
+  platform. On darwin the OS version is baked into the platform string
+  (`arm64-darwin-23` vs `arm64-darwin-24`); a mismatch yields `GemNotFound`.
+- **Point `GEM_HOME` and Bundler's `bundle_path` at the same dir** so
+  `gem install` and `bundle install --local` agree on where the gem lives.
+
+## Known nuance
+
+On the **remote** path the gem currently installs into
+`gems/hola-1.0.0-<real-platform>/`, whereas the **`--local`** path installs into
+`gems/hola-1.0.0-<sha>/`. Both are internally consistent and work for a single
+active Ruby, but they disagree on the on-disk directory name. True
+side-by-side coexistence of two Ruby-minor builds on the remote path would
+require Bundler's installer to preserve the content address into the install
+dir like `gem install` does.

--- a/dev/content-addressable-test/README.md
+++ b/dev/content-addressable-test/README.md
@@ -3,7 +3,7 @@
 Manual, native-macOS (darwin) tests for **content-addressable ("skinny")
 precompiled gems**. 
 
-A *skinny* binary is a platformed gem pinned to a single Ruby minor (here the
+A *skinny* binary is a platformed gem pinned to a single Ruby ABI (here the
 demo's `required_ruby_version = "~> 3.3.0"`). These are built, named, installed,
 and resolved by **content address** — `name-version-<sha>`, where
 `<sha> = sha256(.gem)[0, 10]` — so multiple per-Ruby builds of the same
@@ -13,7 +13,7 @@ version+platform can coexist and the right one is fetched at resolve time.
 
 | File | Purpose |
 | --- | --- |
-| `demo/` | A tiny native gem (`hola`) with a one-Ruby-minor `required_ruby_version`, so it builds as a skinny/content-addressable binary. |
+| `demo/` | A tiny native gem (`hola`) with a one-ABI `required_ruby_version`, so it builds as a skinny/content-addressable binary. |
 | `fake_compact_index.rb` | ~40-line, dependency-free threaded HTTP server that serves a directory as a compact index (`/v2/versions`, `/v2/info/<gem>`, `/gems/*.gem`). |
 | `test_local.sh` | Builds + installs the gem and exercises `bundle install --local`. |
 | `test_remote.sh` | Renders compact-index files, starts the fake server, and exercises a real remote `bundle install`. |
@@ -87,6 +87,6 @@ On the **remote** path the gem currently installs into
 `gems/hola-1.0.0-<real-platform>/`, whereas the **`--local`** path installs into
 `gems/hola-1.0.0-<sha>/`. Both are internally consistent and work for a single
 active Ruby, but they disagree on the on-disk directory name. True
-side-by-side coexistence of two Ruby-minor builds on the remote path would
+side-by-side coexistence of two Ruby ABI builds on the remote path would
 require Bundler's installer to preserve the content address into the install
 dir like `gem install` does.

--- a/dev/content-addressable-test/README.md
+++ b/dev/content-addressable-test/README.md
@@ -18,6 +18,7 @@ version+platform can coexist and the right one is fetched at resolve time.
 | `test_local.sh` | Builds + installs the gem and exercises `bundle install --local`. |
 | `test_remote.sh` | Renders compact-index files, starts the fake server, and exercises a real remote `bundle install`. |
 | `test_remote_mixed.sh` | One Gemfile spanning a v2 source (content-addressable gem) and a scoped v1-only source (traditional gem), proving per-source API negotiation in a single `bundle install`. |
+| `test_remote_reprobe.sh` | A source upgrades v1 -> v2; proves the client re-probes each resolve and switches to v2 (instead of being pinned to v1 forever). |
 
 ## Requirements
 
@@ -36,6 +37,7 @@ cd dev/content-addressable-test
 ./test_local.sh              # bundle install --local path
 ./test_remote.sh             # remote path via the fake compact-index server
 ./test_remote_mixed.sh       # v2 source + scoped v1 source in one Gemfile
+./test_remote_reprobe.sh     # source upgrades v1 -> v2; client re-probes
 ```
 
 > **Note:** these scripts honor a `PORT` env var. If you have `PORT` exported
@@ -94,6 +96,21 @@ end
    own remote, and there is no cross-source leakage. This exercises the
    **per-source** API negotiation: the cache + version marker are keyed by
    `remote.cache_slug`, so v2 and v1 sources coexist in a single resolve.
+
+### `test_remote_reprobe.sh`
+Guards against the negotiated API version being pinned forever. The client
+re-probes on every resolve (the probe's `versions` fetch is an ETag-conditional
+request, so it's a cheap `304` on a warm cache -- the same revalidation pattern
+as `versions`/`info`). The persisted `api_version` marker is kept only as an
+offline fallback:
+1. Serves a v1-only index and installs -> the client probes `/v2/versions`
+   (404), downgrades, and caches `api_version = 1`.
+2. **Upgrades the same source to v2** (adds `/v2/*`).
+3. Re-resolves and asserts the client **re-probes** `/v2/versions` (now 200),
+   rewrites the marker to `2`, and starts fetching the content-addressed
+   `/v2/info/hola` -- no cache-clearing required. If a re-probe can't reach the
+   network, the client falls back to the last persisted version so offline
+   installs against a warm cache still work.
 
 ## Gotchas (learned the hard way; encoded in the scripts)
 

--- a/dev/content-addressable-test/README.md
+++ b/dev/content-addressable-test/README.md
@@ -17,6 +17,7 @@ version+platform can coexist and the right one is fetched at resolve time.
 | `fake_compact_index.rb` | ~40-line, dependency-free threaded HTTP server that serves a directory as a compact index (`/v2/versions`, `/v2/info/<gem>`, `/gems/*.gem`). |
 | `test_local.sh` | Builds + installs the gem and exercises `bundle install --local`. |
 | `test_remote.sh` | Renders compact-index files, starts the fake server, and exercises a real remote `bundle install`. |
+| `test_remote_mixed.sh` | One Gemfile spanning a v2 source (content-addressable gem) and a scoped v1-only source (traditional gem), proving per-source API negotiation in a single `bundle install`. |
 
 ## Requirements
 
@@ -32,9 +33,14 @@ The scripts auto-locate this rubygems checkout (two levels up) and load the
 
 ```bash
 cd dev/content-addressable-test
-./test_local.sh     # bundle install --local path
-./test_remote.sh    # remote path via the fake compact-index server
+./test_local.sh              # bundle install --local path
+./test_remote.sh             # remote path via the fake compact-index server
+./test_remote_mixed.sh       # v2 source + scoped v1 source in one Gemfile
 ```
+
+> **Note:** these scripts honor a `PORT` env var. If you have `PORT` exported
+> in your shell (e.g. pointing at a dev-services proxy on `8080`), pass an
+> explicit one: `PORT=8898 ./test_remote_v1.sh`.
 
 Each prints every step and ends with `ALL GOOD`.
 
@@ -65,6 +71,29 @@ Each prints every step and ends with `ALL GOOD`.
 2. Bundler probes `/v2/versions`, fetches `/v2/info/hola`, resolves
    `hola 1.0.0 (<sha>)`, downloads `/gems/hola-1.0.0-<sha>.gem`, installs it, and
    `require` works.
+
+### `test_remote_mixed.sh`
+Runs **two** fake servers behind one Gemfile -- a v2 source and a scoped
+v1-only source:
+```ruby
+source "http://127.0.0.1:<v2>"        # content-addressable (skinny) hola
+gem "hola"
+
+source "http://127.0.0.1:<v1>" do     # legacy v1-only source (saludo)
+  gem "saludo"
+end
+```
+1. For the v2 source the client fetches `/v2/info/hola`, resolves
+   `hola 1.0.0 (<sha>)`, and downloads `/gems/hola-1.0.0-<sha>.gem`.
+2. For the v1 source the client probes `GET /v2/versions`, gets a **404**, and
+   transparently downgrades to v1 (see
+   `CompactIndexClient#negotiate_api_version!`) -- fetching the unprefixed
+   `/versions` + `/info/saludo` and downloading `/gems/saludo-1.0.0.gem`. No
+   `<sha>` token, no `/v2/info` request.
+3. Asserts both gems install and `require`, the lockfile records each under its
+   own remote, and there is no cross-source leakage. This exercises the
+   **per-source** API negotiation: the cache + version marker are keyed by
+   `remote.cache_slug`, so v2 and v1 sources coexist in a single resolve.
 
 ## Gotchas (learned the hard way; encoded in the scripts)
 

--- a/dev/content-addressable-test/demo/.gitignore
+++ b/dev/content-addressable-test/demo/.gitignore
@@ -1,0 +1,5 @@
+/tmp/
+/pkg/
+/lib/hola/*.bundle
+/lib/hola/*.so
+*.gem

--- a/dev/content-addressable-test/demo/Rakefile
+++ b/dev/content-addressable-test/demo/Rakefile
@@ -1,0 +1,5 @@
+require "rake/extensiontask"
+spec = Gem::Specification.load("hola.gemspec")
+Rake::ExtensionTask.new("hola", spec) do |ext|
+  ext.lib_dir = "lib/hola"
+end

--- a/dev/content-addressable-test/demo/ext/hola/extconf.rb
+++ b/dev/content-addressable-test/demo/ext/hola/extconf.rb
@@ -1,0 +1,2 @@
+require "mkmf"
+create_makefile("hola/hola")

--- a/dev/content-addressable-test/demo/ext/hola/hola.c
+++ b/dev/content-addressable-test/demo/ext/hola/hola.c
@@ -1,0 +1,9 @@
+#include <ruby.h>
+
+static VALUE hola(VALUE self) {
+  return rb_str_new_cstr("hola from native");
+}
+
+void Init_hola(void) {
+  rb_define_global_function("hola", hola, 0);
+}

--- a/dev/content-addressable-test/demo/hola.gemspec
+++ b/dev/content-addressable-test/demo/hola.gemspec
@@ -5,6 +5,6 @@ Gem::Specification.new do |s|
   s.authors     = ["poc"]
   s.files       = Dir["lib/**/*.rb"] + Dir["ext/**/*"]
   s.extensions  = ["ext/hola/extconf.rb"]
-  # A single Ruby minor makes this a "skinny" binary -> content-addressable.
+  # A single Ruby ABI makes this a "skinny" binary -> content-addressable.
   s.required_ruby_version = "~> 3.3.0"
 end

--- a/dev/content-addressable-test/demo/hola.gemspec
+++ b/dev/content-addressable-test/demo/hola.gemspec
@@ -1,0 +1,10 @@
+Gem::Specification.new do |s|
+  s.name        = "hola"
+  s.version     = "1.0.0"
+  s.summary     = "content-addressable native gem demo"
+  s.authors     = ["poc"]
+  s.files       = Dir["lib/**/*.rb"] + Dir["ext/**/*"]
+  s.extensions  = ["ext/hola/extconf.rb"]
+  # A single Ruby minor makes this a "skinny" binary -> content-addressable.
+  s.required_ruby_version = "~> 3.3.0"
+end

--- a/dev/content-addressable-test/demo/lib/hola.rb
+++ b/dev/content-addressable-test/demo/lib/hola.rb
@@ -1,0 +1,1 @@
+require "hola/hola"

--- a/dev/content-addressable-test/fake_compact_index.rb
+++ b/dev/content-addressable-test/fake_compact_index.rb
@@ -1,0 +1,59 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+#
+# Minimal compact-index gem server for testing content-addressable ("skinny")
+# binaries end-to-end, with no external deps (raw TCPServer, threaded).
+#
+# Serves a directory tree as static files over HTTP/1.1:
+#   GET /v2/versions      -> <root>/v2/versions
+#   GET /v2/info/<gem>    -> <root>/v2/info/<gem>
+#   GET /gems/<file>.gem  -> <root>/gems/<file>.gem
+#
+# Always returns the full body (200); ignores Range (Bundler's compact-index
+# updater handles a full response even when it sent a Range header). Logs every
+# request to stderr so you can see exactly what Bundler asks for.
+#
+# Usage: ruby fake_compact_index.rb <root_dir> <port>
+
+require "socket"
+
+root = File.expand_path(ARGV[0] || ".")
+port = Integer(ARGV[1] || "8899")
+
+server = TCPServer.new("127.0.0.1", port)
+warn "[fake-index] serving #{root} on http://127.0.0.1:#{port}"
+
+loop do
+  conn = server.accept
+  Thread.new(conn) do |c|
+    begin
+      request_line = c.gets
+      next unless request_line
+      method, path, = request_line.split(" ")
+      # drain headers
+      while (line = c.gets) && line != "\r\n"; end
+
+      clean = path.split("?", 2).first.to_s
+      file = File.join(root, clean)
+      warn "[fake-index] #{method} #{clean} -> #{File.exist?(file) ? "200" : "404"}"
+
+      if File.file?(file)
+        body = File.binread(file)
+        ctype = clean.end_with?(".gem") ? "application/octet-stream" : "text/plain"
+        head = +"HTTP/1.1 200 OK\r\n"
+        head << "Content-Type: #{ctype}\r\n"
+        head << "Content-Length: #{body.bytesize}\r\n"
+        head << "Accept-Ranges: none\r\n"
+        head << "Connection: close\r\n\r\n"
+        c.write(head)
+        c.write(body) unless method == "HEAD"
+      else
+        c.write("HTTP/1.1 404 Not Found\r\nContent-Length: 0\r\nConnection: close\r\n\r\n")
+      end
+    rescue => e
+      warn "[fake-index] error: #{e.class}: #{e.message}"
+    ensure
+      c.close rescue nil
+    end
+  end
+end

--- a/dev/content-addressable-test/test_local.sh
+++ b/dev/content-addressable-test/test_local.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+#
+# End-to-end test of content-addressable ("skinny") precompiled gems over the
+# LOCAL path (bundle install --local), natively on macOS. No containers.
+#
+# Proves:
+#   - `rake native gem` builds a skinny gem and renames it to name-version-<sha>.gem
+#   - `gem install` installs it under gems/name-version-<sha>/ with the sha in the stub
+#   - `bundle install --local` resolves the content-addressed gem (incl. lockfile round-trip)
+#   - `bundle exec require` + `bundle list` work
+#
+# Override the ruby with: RUBY_PREFIX=/opt/rubies/3.3.x ./test_local.sh
+set -euo pipefail
+
+RUBY_PREFIX="${RUBY_PREFIX:-/opt/rubies/3.3.5}"   # clean ruby satisfying demo's ~> 3.3.0
+HERE="$(cd "$(dirname "$0")" && pwd)"
+RG="$(cd "$HERE/../.." && pwd)"                    # this rubygems checkout (patched)
+DEMO="$HERE/demo"
+WORK=/tmp/ca-local
+
+export PATH="$RUBY_PREFIX/bin:$PATH"
+export GEM_HOME="$WORK/gemhome" GEM_PATH="$WORK/gemhome"
+RUBY="$RUBY_PREFIX/bin/ruby"
+BUNDLE="$RUBY -I$RG/bundler/lib $RG/bundler/exe/bundle"
+
+rm -rf "$WORK"; mkdir -p "$WORK/gemhome" "$WORK/app"
+echo "ruby: $($RUBY -e 'print RUBY_VERSION, " ", RUBY_PLATFORM')"
+
+echo "== install released rake-compiler (clean RubyGems) =="
+$RUBY -S gem install rake-compiler --no-document >/dev/null
+
+echo "== build native gem (patched RubyGems loaded over installed gems) =="
+cd "$DEMO"; rm -rf tmp pkg lib/hola/*.bundle lib/hola/*.so
+RUBYOPT="--disable-gems -I$RG/lib -rrubygems" $RUBY -S rake native gem 2>&1 | grep -E "File|Content-addressed"
+GEM=$(ls pkg/hola-1.0.0-*.gem)
+
+# everything below uses the patched RubyGems
+export RUBYOPT="--disable-gems -I$RG/lib -rrubygems"
+
+echo "== gem install --local =="
+$RUBY -S gem install --local "$GEM" --no-document | grep -i installed
+echo "   install dir : $(basename "$(ls -d "$GEM_HOME"/gems/hola-*)")"
+echo "   stub line   : $(grep '# stub:' "$GEM_HOME"/specifications/hola-*.gemspec)"
+
+echo "== bundle install --local =="
+cd "$WORK/app"
+printf 'source "http://example.invalid"\ngem "hola"\n' > Gemfile
+$BUNDLE install --local 2>&1 | grep -iE "complete|could not"
+echo "   lockfile    : $(grep -A1 'specs:' Gemfile.lock | tail -1 | xargs)"
+
+echo "== bundle exec require =="
+$BUNDLE exec ruby -e 'require "hola"; puts "   => " + hola'
+
+echo "== bundle install --local AGAIN (idempotent, reads lock) =="
+$BUNDLE install --local 2>&1 | grep -iE "complete|could not"
+
+echo "== bundle list =="
+$BUNDLE list | grep hola
+
+echo "ALL GOOD"

--- a/dev/content-addressable-test/test_remote.sh
+++ b/dev/content-addressable-test/test_remote.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+#
+# End-to-end test of a content-addressable ("skinny") gem over the REMOTE path:
+# Bundler resolves and downloads it from a fake compact-index server. No
+# rubygems.org, no containers.
+#
+# Proves: Bundler probes /v2/versions, parses the content-addressed info line
+# (version slot = <sha>, platform: token = real platform), downloads
+# /gems/hola-1.0.0-<sha>.gem, installs it, and `require` works.
+#
+# Override the ruby with: RUBY_PREFIX=/opt/rubies/3.3.x ./test_remote.sh
+set -euo pipefail
+
+RUBY_PREFIX="${RUBY_PREFIX:-/opt/rubies/3.3.5}"
+HERE="$(cd "$(dirname "$0")" && pwd)"
+RG="$(cd "$HERE/../.." && pwd)"
+DEMO="$HERE/demo"
+WORK=/tmp/ca-remote
+PORT="${PORT:-8899}"
+
+export PATH="$RUBY_PREFIX/bin:$PATH"
+export GEM_HOME="$WORK/gemhome" GEM_PATH="$WORK/gemhome"
+RUBY="$RUBY_PREFIX/bin/ruby"
+BUNDLE="$RUBY -I$RG/bundler/lib $RG/bundler/exe/bundle"
+
+rm -rf "$WORK"; mkdir -p "$WORK/gemhome" "$WORK/app" "$WORK/srv/gems" "$WORK/srv/v2/info"
+echo "ruby: $($RUBY -e 'print RUBY_VERSION, " ", RUBY_PLATFORM')"
+
+echo "== install released rake-compiler + build content-addressed gem =="
+$RUBY -S gem install rake-compiler --no-document >/dev/null
+cd "$DEMO"; rm -rf tmp pkg lib/hola/*.bundle lib/hola/*.so
+RUBYOPT="--disable-gems -I$RG/lib -rrubygems" $RUBY -S rake native gem 2>&1 | grep -E "Content-addressed"
+GEM=$(ls pkg/hola-1.0.0-*.gem)
+cp "$GEM" "$WORK/srv/gems/"
+echo "   gem: $(basename "$GEM")"
+
+echo "== render compact-index files from the gem =="
+RUBYOPT="--disable-gems -I$RG/lib -rrubygems" $RUBY - "$GEM" "$WORK/srv" <<'RUBY'
+require "rubygems/package"
+require "digest"
+gemfile, srv = ARGV
+spec   = Gem::Package.new(gemfile).spec
+sha256 = Digest::SHA256.hexdigest(File.binread(gemfile))
+addr   = sha256[0, 10]                                  # content address == sha in the filename
+real   = spec.platform.to_s                             # e.g. arm64-darwin-23
+ruby   = spec.required_ruby_version.as_list.join("&")   # e.g. "~> 3.3.0"
+
+# info line: "<version>-<sha> |checksum:<sha256>,ruby:<req>,platform:<real>"
+info = +"---\n"
+info << "#{spec.version}-#{addr} |checksum:#{sha256},ruby:#{ruby},platform:#{real}\n"
+File.write(File.join(srv, "v2/info/hola"), info)
+
+# versions line: "<name> <version>-<sha> <md5-of-info>"
+versions = +"created_at: 2024-01-01T00:00:00Z\n---\n"
+versions << "hola #{spec.version}-#{addr} #{Digest::MD5.hexdigest(info)}\n"
+File.write(File.join(srv, "v2/versions"), versions)
+
+warn "   filename sha == sha256[0,10]? #{File.basename(gemfile).include?(addr)}"
+warn "   /v2/info/hola: #{info.lines.last.chomp}"
+RUBY
+
+# IMPORTANT: bundle must load the PATCHED rubygems core (content-addressable
+# Gem::Platform), not Ruby's built-in rubygems, or the <sha> platform token
+# normalizes to "unknown".
+export RUBYOPT="--disable-gems -I$RG/lib -rrubygems"
+
+echo "== start fake compact-index server =="
+$RUBY "$HERE/fake_compact_index.rb" "$WORK/srv" "$PORT" 2>"$WORK/srv.log" &
+SRV=$!
+trap 'kill $SRV 2>/dev/null || true' EXIT
+sleep 1
+
+echo "== bundle install (REMOTE, from fake server) =="
+cd "$WORK/app"
+printf 'source "http://127.0.0.1:%s"\ngem "hola"\n' "$PORT" > Gemfile
+$BUNDLE install 2>&1 | grep -iE "fetching|installing|complete|could not|error" || true
+echo "   installed: $(basename "$(ls -d "$GEM_HOME"/gems/hola-* 2>/dev/null)")"
+
+echo "== bundle exec require =="
+$BUNDLE exec ruby -e 'require "hola"; puts "   => " + hola'
+
+echo
+echo "== server request log =="
+sed 's/^/   /' "$WORK/srv.log"
+echo "ALL GOOD"

--- a/dev/content-addressable-test/test_remote_mixed.sh
+++ b/dev/content-addressable-test/test_remote_mixed.sh
@@ -32,6 +32,11 @@ PORT_V1="${PORT_V1:-8912}"
 
 export PATH="$RUBY_PREFIX/bin:$PATH"
 export GEM_HOME="$WORK/gemhome" GEM_PATH="$WORK/gemhome"
+# Isolate Bundler's user cache under $WORK so each run is COLD. Otherwise the
+# per-source `api_version` marker (and cached info) persist in ~/.bundle/cache
+# keyed by source URL, and a re-run skips the /v2 probe -> the negotiation
+# assertions below would be non-deterministic.
+export BUNDLE_USER_HOME="$WORK/bundle-user"
 RUBY="$RUBY_PREFIX/bin/ruby"
 BUNDLE="$RUBY -I$RG/bundler/lib $RG/bundler/exe/bundle"
 

--- a/dev/content-addressable-test/test_remote_mixed.sh
+++ b/dev/content-addressable-test/test_remote_mixed.sh
@@ -1,0 +1,161 @@
+#!/usr/bin/env bash
+#
+# End-to-end test of a single Gemfile that resolves across a v2 source and a v1
+# source at the same time:
+#
+#     source "http://127.0.0.1:<v2>"        # content-addressable (skinny) hola
+#     gem "hola"
+#
+#     source "http://127.0.0.1:<v1>" do     # legacy v1-only source (saludo)
+#       gem "saludo"
+#     end
+#
+# Two fake servers run side by side. The v2 server serves `/v2/versions` +
+# `/v2/info/hola` (content-addressed tokens). The v1 server serves ONLY the
+# unprefixed `/versions` + `/info/saludo` and 404s the `/v2/versions` probe.
+#
+# Proves the per-source API negotiation: in one `bundle install` the client
+# speaks v2 to the first source (downloads hola-1.0.0-<sha>.gem) and downgrades
+# to v1 for the second (downloads saludo-1.0.0.gem), with no cross-source
+# leakage. Both gems install and `require`.
+#
+# Override the ruby with: RUBY_PREFIX=/opt/rubies/3.3.x ./test_remote_mixed.sh
+set -euo pipefail
+
+RUBY_PREFIX="${RUBY_PREFIX:-/opt/rubies/3.3.5}"
+HERE="$(cd "$(dirname "$0")" && pwd)"
+RG="$(cd "$HERE/../.." && pwd)"
+DEMO="$HERE/demo"
+WORK=/tmp/ca-remote-mixed
+PORT_V2="${PORT_V2:-8911}"
+PORT_V1="${PORT_V1:-8912}"
+
+export PATH="$RUBY_PREFIX/bin:$PATH"
+export GEM_HOME="$WORK/gemhome" GEM_PATH="$WORK/gemhome"
+RUBY="$RUBY_PREFIX/bin/ruby"
+BUNDLE="$RUBY -I$RG/bundler/lib $RG/bundler/exe/bundle"
+
+rm -rf "$WORK"
+mkdir -p "$WORK/gemhome" "$WORK/app" \
+         "$WORK/srv_v2/gems" "$WORK/srv_v2/v2/info" \
+         "$WORK/srv_v1/gems" "$WORK/srv_v1/info" \
+         "$WORK/saludo/lib"
+echo "ruby: $($RUBY -e 'print RUBY_VERSION, " ", RUBY_PLATFORM')"
+
+echo "== install released rake-compiler + build content-addressed gem (hola) =="
+$RUBY -S gem install rake-compiler --no-document >/dev/null
+cd "$DEMO"; rm -rf tmp pkg lib/hola/*.bundle lib/hola/*.so
+RUBYOPT="--disable-gems -I$RG/lib -rrubygems" $RUBY -S rake native gem 2>&1 | grep -E "Content-addressed"
+HOLA=$(ls pkg/hola-1.0.0-*.gem)
+cp "$HOLA" "$WORK/srv_v2/gems/"
+echo "   v2 gem: $(basename "$HOLA")"
+
+echo "== build a plain pure-ruby gem (saludo) for the v1 source =="
+cat > "$WORK/saludo/saludo.gemspec" <<'GEMSPEC'
+Gem::Specification.new do |s|
+  s.name        = "saludo"
+  s.version     = "1.0.0"
+  s.summary     = "plain pure-ruby gem served from a v1-only source"
+  s.authors     = ["poc"]
+  s.files       = Dir["lib/**/*.rb"]
+end
+GEMSPEC
+cat > "$WORK/saludo/lib/saludo.rb" <<'RB'
+def saludo
+  "hola from saludo (v1 source)"
+end
+RB
+( cd "$WORK/saludo" && RUBYOPT="--disable-gems -I$RG/lib -rrubygems" $RUBY -S gem build saludo.gemspec >/dev/null )
+SALUDO=$(ls "$WORK/saludo"/saludo-1.0.0.gem)
+cp "$SALUDO" "$WORK/srv_v1/gems/"
+echo "   v1 gem: $(basename "$SALUDO")"
+
+echo "== render a v2 index for hola and a v1 index for saludo =="
+RUBYOPT="--disable-gems -I$RG/lib -rrubygems" $RUBY - \
+  "$HOLA" "$WORK/srv_v2" "$SALUDO" "$WORK/srv_v1" <<'RUBY'
+require "rubygems/package"
+require "digest"
+
+hola_gem, v2, saludo_gem, v1 = ARGV
+
+# --- v2 source: content-addressable hola, served under /v2/ -----------------
+spec   = Gem::Package.new(hola_gem).spec
+sha256 = Digest::SHA256.hexdigest(File.binread(hola_gem))
+addr   = sha256[0, 10]
+real   = spec.platform.to_s
+ruby   = spec.required_ruby_version.as_list.join("&")
+info = +"---\n"
+info << "#{spec.version}-#{addr} |checksum:#{sha256},ruby:#{ruby},platform:#{real}\n"
+File.write(File.join(v2, "v2/info/hola"), info)
+versions = +"created_at: 2024-01-01T00:00:00Z\n---\n"
+versions << "hola #{spec.version}-#{addr} #{Digest::MD5.hexdigest(info)}\n"
+File.write(File.join(v2, "v2/versions"), versions)
+warn "   [v2] /v2/info/hola: #{info.lines.last.chomp}"
+
+# --- v1 source: plain saludo, UNPREFIXED (no /v2/, no <sha> token) ----------
+sspec   = Gem::Package.new(saludo_gem).spec
+ssha256 = Digest::SHA256.hexdigest(File.binread(saludo_gem))
+sinfo = +"---\n"
+sinfo << "#{sspec.version} |checksum:#{ssha256}\n"
+File.write(File.join(v1, "info/saludo"), sinfo)
+sversions = +"created_at: 2024-01-01T00:00:00Z\n---\n"
+sversions << "saludo #{sspec.version} #{Digest::MD5.hexdigest(sinfo)}\n"
+File.write(File.join(v1, "versions"), sversions)
+warn "   [v1] /info/saludo: #{sinfo.lines.last.chomp}"
+RUBY
+
+# IMPORTANT: bundle must load the PATCHED rubygems core (content-addressable
+# Gem::Platform), not Ruby's built-in rubygems.
+export RUBYOPT="--disable-gems -I$RG/lib -rrubygems"
+
+echo "== start two fake servers: v2 source + v1-only source =="
+$RUBY "$HERE/fake_compact_index.rb" "$WORK/srv_v2" "$PORT_V2" 2>"$WORK/srv_v2.log" &
+SRV_V2=$!
+$RUBY "$HERE/fake_compact_index.rb" "$WORK/srv_v1" "$PORT_V1" 2>"$WORK/srv_v1.log" &
+SRV_V1=$!
+trap 'kill $SRV_V2 $SRV_V1 2>/dev/null || true' EXIT
+sleep 1
+
+echo "== bundle install (one Gemfile: v2 source + scoped v1 source) =="
+cd "$WORK/app"
+cat > Gemfile <<GEMFILE
+source "http://127.0.0.1:$PORT_V2"
+gem "hola"
+
+source "http://127.0.0.1:$PORT_V1" do
+  gem "saludo"
+end
+GEMFILE
+$BUNDLE install 2>&1 | grep -iE "fetching|installing|complete|could not|error" || true
+echo "   installed hola  : $(basename "$(ls -d "$GEM_HOME"/gems/hola-*   2>/dev/null)")"
+echo "   installed saludo: $(basename "$(ls -d "$GEM_HOME"/gems/saludo-* 2>/dev/null)")"
+
+echo "== assert per-source API negotiation =="
+if grep -q "GET /v2/info/hola -> 200" "$WORK/srv_v2.log" && grep -q "GET /gems/hola-1.0.0-" "$WORK/srv_v2.log"; then
+  echo "   OK: v2 source served /v2/info/hola + content-addressed gem"
+else
+  echo "   FAIL: v2 source did not serve hola over v2"; exit 1
+fi
+if grep -q "GET /v2/versions -> 404" "$WORK/srv_v1.log" && grep -q "GET /info/saludo -> 200" "$WORK/srv_v1.log"; then
+  echo "   OK: v1 source 404'd the /v2 probe and served /info/saludo over v1"
+else
+  echo "   FAIL: v1 source did not downgrade as expected"; exit 1
+fi
+if grep -q "GET /v2/info/saludo" "$WORK/srv_v1.log"; then
+  echo "   FAIL: client requested a /v2/info entry on the v1-only source"; exit 1
+else
+  echo "   OK: no /v2/info request on the v1 source"
+fi
+
+echo "== bundle exec require (both gems) =="
+$BUNDLE exec ruby -e 'require "hola"; require "saludo"; puts "   => " + hola + " | " + saludo'
+
+echo "== lockfile =="
+grep -nE "remote:|hola|saludo" Gemfile.lock | sed 's/^/   /'
+
+echo
+echo "== v2 server request log =="
+sed 's/^/   [v2] /' "$WORK/srv_v2.log"
+echo "== v1 server request log =="
+sed 's/^/   [v1] /' "$WORK/srv_v1.log"
+echo "ALL GOOD"

--- a/dev/content-addressable-test/test_remote_reprobe.sh
+++ b/dev/content-addressable-test/test_remote_reprobe.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+#
+# Regression test for API-version RE-PROBING.
+#
+# Before: once a source negotiated v1, the persisted `api_version` marker pinned
+# it to v1 FOREVER -- a source that later added v2 support was ignored until the
+# cache was cleared by hand.
+#
+# Now: the client re-probes on every resolve (the probe's `versions` fetch is an
+# ETag-conditional request, so it's cheap on a warm cache), so an upgrade to v2
+# is picked up. The persisted marker is kept only as an offline fallback.
+#
+# This test:
+#   1. Serves a v1-only index, installs -> client negotiates + caches v1.
+#   2. Upgrades the SAME source to v2 (adds /v2/*).
+#   3. Re-resolves and asserts the client re-probed /v2/versions and switched
+#      to v2 (no cache-clearing or marker surgery required).
+#
+# Override the ruby with: RUBY_PREFIX=/opt/rubies/3.3.x ./test_remote_reprobe.sh
+set -euo pipefail
+
+RUBY_PREFIX="${RUBY_PREFIX:-/opt/rubies/3.3.5}"
+HERE="$(cd "$(dirname "$0")" && pwd)"
+RG="$(cd "$HERE/../.." && pwd)"
+DEMO="$HERE/demo"
+WORK=/tmp/ca-remote-reprobe
+PORT="${PORT_REPROBE:-8921}"
+
+export PATH="$RUBY_PREFIX/bin:$PATH"
+export GEM_HOME="$WORK/gemhome" GEM_PATH="$WORK/gemhome"
+export BUNDLE_USER_HOME="$WORK/bundle-user"   # isolate compact_index cache under $WORK
+RUBY="$RUBY_PREFIX/bin/ruby"
+BUNDLE="$RUBY -I$RG/bundler/lib $RG/bundler/exe/bundle"
+
+rm -rf "$WORK"; mkdir -p "$WORK/gemhome" "$WORK/app" "$WORK/srv/gems" "$WORK/srv/info" "$WORK/srv/v2/info"
+echo "ruby: $($RUBY -e 'print RUBY_VERSION, " ", RUBY_PLATFORM')"
+
+echo "== build the content-addressed gem (hola) =="
+$RUBY -S gem install rake-compiler --no-document >/dev/null
+cd "$DEMO"; rm -rf tmp pkg lib/hola/*.bundle lib/hola/*.so
+RUBYOPT="--disable-gems -I$RG/lib -rrubygems" $RUBY -S rake native gem 2>&1 | grep -E "Content-addressed"
+GEM=$(ls pkg/hola-1.0.0-*.gem)
+
+echo "== render BOTH a v1 index (active now) and a v2 index (added in step 2) =="
+RUBYOPT="--disable-gems -I$RG/lib -rrubygems" $RUBY - "$GEM" "$WORK/srv" <<'RUBY'
+require "rubygems/package"; require "digest"; require "fileutils"
+gemfile, srv = ARGV
+spec   = Gem::Package.new(gemfile).spec
+sha256 = Digest::SHA256.hexdigest(File.binread(gemfile))
+addr   = sha256[0, 10]
+real   = spec.platform.to_s
+ruby   = spec.required_ruby_version.as_list.join("&")
+
+# v1 (traditional): real platform in version slot, served as hola-1.0.0-<real>.gem
+full_v1 = "#{spec.name}-#{spec.version}-#{real}"
+FileUtils.cp(gemfile, File.join(srv, "gems", "#{full_v1}.gem"))
+info1 = +"---\n#{spec.version}-#{real} |checksum:#{sha256},ruby:#{ruby}\n"
+File.write(File.join(srv, "info/hola"), info1)
+File.write(File.join(srv, "versions"),
+           "created_at: 2024-01-01T00:00:00Z\n---\nhola #{spec.version}-#{real} #{Digest::MD5.hexdigest(info1)}\n")
+
+# v2 (content-addressable): staged under v2/, served as hola-1.0.0-<sha>.gem
+FileUtils.cp(gemfile, File.join(srv, "gems", "#{spec.name}-#{spec.version}-#{addr}.gem"))
+info2 = +"---\n#{spec.version}-#{addr} |checksum:#{sha256},ruby:#{ruby},platform:#{real}\n"
+File.write(File.join(srv, "v2/info/hola"), info2)
+File.write(File.join(srv, "v2/versions"),
+           "created_at: 2024-01-01T00:00:00Z\n---\nhola #{spec.version}-#{addr} #{Digest::MD5.hexdigest(info2)}\n")
+warn "   v1 /info/hola : #{info1.lines.last.chomp}"
+warn "   v2 /v2/info/hola: #{info2.lines.last.chomp}"
+RUBY
+
+export RUBYOPT="--disable-gems -I$RG/lib -rrubygems"
+
+# ---------------------------------------------------------------------------
+echo "== STEP 1: serve v1 ONLY, install -> negotiate + cache v1 =="
+mv "$WORK/srv/v2" "$WORK/v2_staged"   # hide v2 so /v2/versions 404s
+$RUBY "$HERE/fake_compact_index.rb" "$WORK/srv" "$PORT" 2>"$WORK/srv1.log" & SRV=$!
+trap 'kill $SRV 2>/dev/null || true' EXIT
+sleep 1
+cd "$WORK/app"
+printf 'source "http://127.0.0.1:%s"\ngem "hola"\n' "$PORT" > Gemfile
+$BUNDLE install 2>&1 | grep -iE "installing|complete" || true
+MARKER=$(ls "$BUNDLE_USER_HOME"/cache/compact_index/*/api_version)
+echo "   cached api_version = $(cat "$MARKER")  (expect 1)"
+[ "$(cat "$MARKER")" = "1" ] || { echo "   FAIL: expected v1 to be cached"; exit 1; }
+kill $SRV 2>/dev/null || true; sleep 1
+
+# ---------------------------------------------------------------------------
+echo "== STEP 2: UPGRADE the same source to v2 (add /v2/*) =="
+mv "$WORK/v2_staged" "$WORK/srv/v2"
+rm -f Gemfile.lock   # force a fresh resolve against the index
+$RUBY "$HERE/fake_compact_index.rb" "$WORK/srv" "$PORT" 2>"$WORK/srv2.log" & SRV=$!
+sleep 1
+
+echo "== STEP 3: re-resolve -> client should re-probe and switch to v2 =="
+$BUNDLE install 2>&1 | grep -iE "installing|complete|fetching hola" || true
+echo "   cached api_version = $(cat "$MARKER")  (expect 2)"
+
+echo "== assertions =="
+if grep -q "GET /v2/versions -> 200" "$WORK/srv2.log"; then
+  echo "   OK: re-probed /v2/versions after the source upgraded"
+else
+  echo "   FAIL: client never re-probed /v2 (still pinned to v1)"; exit 1
+fi
+if [ "$(cat "$MARKER")" = "2" ]; then
+  echo "   OK: marker upgraded v1 -> v2"
+else
+  echo "   FAIL: marker did not upgrade to v2"; exit 1
+fi
+if grep -q "GET /v2/info/hola -> 200" "$WORK/srv2.log"; then
+  echo "   OK: now fetching content-addressed /v2/info/hola"
+else
+  echo "   FAIL: did not fetch v2 info"; exit 1
+fi
+
+echo
+echo "== step-1 (v1) request log =="; sed 's/^/   /' "$WORK/srv1.log"
+echo "== step-3 (after upgrade) request log =="; sed 's/^/   /' "$WORK/srv2.log"
+echo "ALL GOOD"

--- a/lib/rubygems/basic_specification.rb
+++ b/lib/rubygems/basic_specification.rb
@@ -30,6 +30,14 @@ class Gem::BasicSpecification
 
   attr_writer :full_gem_path # :nodoc:
 
+  ##
+  # The content address (first 10 hex of the gem's sha256) for a content-
+  # addressable ("skinny") binary. When set, it replaces the platform in
+  # +full_name+, so the gem downloads/installs/stubs under name-version-<sha>.
+  # nil for ordinary gems.
+
+  attr_accessor :content_address # :nodoc:
+
   def initialize
     internal_init
   end
@@ -145,7 +153,9 @@ class Gem::BasicSpecification
   # default Ruby platform.
 
   def full_name
-    if platform == Gem::Platform::RUBY || platform.nil?
+    if content_address
+      "#{name}-#{version}-#{content_address}"
+    elsif platform == Gem::Platform::RUBY || platform.nil?
       "#{name}-#{version}"
     else
       "#{name}-#{version}-#{platform}"

--- a/lib/rubygems/installer.rb
+++ b/lib/rubygems/installer.rb
@@ -247,6 +247,16 @@ class Gem::Installer
     @gem_dir ||= File.join(gem_home, "gems", spec.full_name)
   end
 
+  def assign_content_address
+    return unless spec.content_addressable?
+    return unless @package.gem.respond_to?(:path)
+
+    require "digest"
+    spec.content_address = Digest::SHA256.file(@package.gem.path).hexdigest[0, 10]
+  rescue StandardError
+    nil
+  end
+
   ##
   # Lazy accessor for the installer's spec.
 
@@ -266,6 +276,11 @@ class Gem::Installer
   #     specifications/<gem-version>.gemspec #=> the Gem::Specification
 
   def install
+    # For a content-addressable ("skinny") binary, derive the content address
+    # from the gem's bytes so full_name -> gems/name-version-<sha>/ and the stub
+    # records the sha. Must run before any path (gem_dir/spec_file) is computed.
+    assign_content_address
+
     pre_install_checks
 
     run_pre_install_hooks

--- a/lib/rubygems/package.rb
+++ b/lib/rubygems/package.rb
@@ -136,7 +136,7 @@ class Gem::Package
     package.spec = spec
     package.build skip_validation, strict_validation
 
-    # Content-address skinny binaries (platformed + single Ruby minor): rename
+    # Content-address skinny binaries (platformed + single Ruby ABI): rename
     # name-version-platform.gem to name-version-<sha10>.gem so multiple per-Ruby
     # builds of the same version+platform can coexist. Skipped when an explicit
     # output file name was requested.

--- a/lib/rubygems/package.rb
+++ b/lib/rubygems/package.rb
@@ -136,6 +136,19 @@ class Gem::Package
     package.spec = spec
     package.build skip_validation, strict_validation
 
+    # Content-address skinny binaries (platformed + single Ruby minor): rename
+    # name-version-platform.gem to name-version-<sha10>.gem so multiple per-Ruby
+    # builds of the same version+platform can coexist. Skipped when an explicit
+    # output file name was requested.
+    if file_name.nil? && spec.content_addressable?
+      require "digest"
+      sha = Digest::SHA256.file(gem_file).hexdigest[0, 10]
+      content_addressed = "#{spec.name}-#{spec.version}-#{sha}.gem"
+      File.rename(gem_file, content_addressed)
+      package.say "  Content-addressed: #{content_addressed}"
+      gem_file = content_addressed
+    end
+
     gem_file
   end
 

--- a/lib/rubygems/package_task.rb
+++ b/lib/rubygems/package_task.rb
@@ -111,10 +111,12 @@ class Gem::PackageTask < Rake::PackageTask
     file gem_path => [package_dir, gem_dir] + @gem_spec.files do
       chdir(gem_dir) do
         when_writing "Creating #{gem_spec.file_name}" do
-          Gem::Package.build gem_spec
+          # build may content-address the file (skinny binaries), so move the
+          # name it actually produced rather than the assumed platform name.
+          built_file = File.basename(Gem::Package.build(gem_spec))
 
           verbose trace do
-            mv gem_file, ".."
+            mv built_file, ".."
           end
         end
       end

--- a/lib/rubygems/platform.rb
+++ b/lib/rubygems/platform.rb
@@ -10,6 +10,11 @@ class Gem::Platform
 
   attr_accessor :cpu, :os, :version
 
+  # For content-addressable ("skinny") binaries, the "platform" token is a
+  # 10-char hex prefix of the gem's SHA256 rather than a real cpu/os/version.
+  # It is kept in its own field so it never masquerades as an operating system.
+  attr_reader :content_address
+
   def self.local(refresh: false)
     return @local if @local && !refresh
     @local = begin
@@ -72,11 +77,44 @@ class Gem::Platform
     end
   end
 
+  ##
+  # A content-address "platform" is a 10-char hex prefix of a gem's SHA256
+  # checksum, used by content-addressable ("skinny") binaries. The real
+  # platform lives in the compact index `platform:` requirement instead of in
+  # the version token.
+
+  CONTENT_ADDRESS = /\A[0-9a-f]{10}\z/
+
+  def self.content_address?(string)
+    string.is_a?(String) && CONTENT_ADDRESS.match?(string)
+  end
+
+  def content_address?
+    !@content_address.nil?
+  end
+
   def initialize(arch)
+    @content_address = nil
+
     case arch
     when Array then
-      @cpu, @os, @version = arch
+      cpu, os, version = arch
+      # Round-trip a content address that was serialized via #to_a.
+      if cpu.nil? && version.nil? && Gem::Platform.content_address?(os)
+        @content_address = os
+      else
+        @cpu, @os, @version = cpu, os, version
+      end
     when String then
+      # Preserve content-address SHA prefixes verbatim (e.g. "ef716ba7a6").
+      # They have no cpu/os/version; otherwise they would normalize to
+      # os="unknown", destroying the hash used in filenames, lockfile
+      # entries, and download URLs.
+      if Gem::Platform.content_address?(arch)
+        @content_address = arch
+        return
+      end
+
       cpu, os = arch.sub(/-+$/, "").split("-", 2)
 
       @cpu = if cpu&.match?(/i\d86/)
@@ -122,17 +160,20 @@ class Gem::Platform
       @cpu = arch.cpu
       @os = arch.os
       @version = arch.version
+      @content_address = arch.content_address
     else
       raise ArgumentError, "invalid argument #{arch.inspect}"
     end
   end
 
   def to_a
+    return [nil, @content_address, nil] if content_address?
     [@cpu, @os, @version]
   end
 
   def to_s
-    to_a.compact.join(@cpu.nil? ? "" : "-")
+    return @content_address if content_address?
+    [@cpu, @os, @version].compact.join(@cpu.nil? ? "" : "-")
   end
 
   ##
@@ -171,13 +212,13 @@ class Gem::Platform
   # the same CPU, OS and version.
 
   def ==(other)
-    self.class === other && to_a == other.to_a
+    self.class === other && content_address == other.content_address && to_a == other.to_a
   end
 
   alias_method :eql?, :==
 
   def hash # :nodoc:
-    to_a.hash
+    [@content_address, @cpu, @os, @version].hash
   end
 
   ##
@@ -200,6 +241,12 @@ class Gem::Platform
 
   def ===(other)
     return nil unless Gem::Platform === other
+
+    # A content address only matches the identical content address; it never
+    # fuzzy-matches a real platform (and vice versa).
+    if content_address? || other.content_address?
+      return content_address == other.content_address
+    end
 
     # universal-mingw32 matches x64-mingw-ucrt
     return true if (@cpu == "universal" || other.cpu == "universal") &&

--- a/lib/rubygems/specification.rb
+++ b/lib/rubygems/specification.rb
@@ -557,6 +557,52 @@ class Gem::Specification < Gem::BasicSpecification
   end
 
   ##
+  # True for a "skinny" precompiled binary: a platformed gem pinned to a single
+  # Ruby minor series. These are content-addressed (name-version-<sha>) at build
+  # time so multiple per-Ruby builds of the same version+platform can coexist.
+  # Fat binaries (spanning many Ruby minors) and source gems are not.
+
+  def content_addressable?
+    return false if platform.nil? || platform == Gem::Platform::RUBY
+
+    !content_addressable_ruby_minor.nil?
+  end
+
+  ##
+  # The single "MAJOR.MINOR" Ruby series this gem targets, or nil if it spans
+  # more than one. Recognizes both `~> X.Y.Z` and the `>= X.Y, < X.(Y+1).dev`
+  # range rake-compiler emits for single-Ruby native gems.
+
+  def content_addressable_ruby_minor
+    reqs = required_ruby_version.requirements
+    return nil if reqs.empty?
+
+    if reqs.size == 1
+      operator, version = reqs.first
+      return nil unless operator == "~>"
+      segments = version.segments
+      return nil unless segments.size >= 3
+
+      return segments.first(2).join(".")
+    end
+
+    if reqs.size == 2
+      lower = reqs.find {|op, _| [">=", ">"].include?(op) }
+      upper = reqs.find {|op, _| ["<", "<="].include?(op) }
+      return nil unless lower && upper
+
+      lo = lower.last.segments
+      hi = upper.last.segments
+      return nil unless lo.size >= 2 && hi.size >= 2
+      return nil unless hi[0] == lo[0] && hi[1] == lo[1] + 1
+
+      return lo.first(2).join(".")
+    end
+
+    nil
+  end
+
+  ##
   # Executables included in the gem.
   #
   # For example, the rake gem has rake as an executable. You don't specify the

--- a/lib/rubygems/specification.rb
+++ b/lib/rubygems/specification.rb
@@ -558,22 +558,22 @@ class Gem::Specification < Gem::BasicSpecification
 
   ##
   # True for a "skinny" precompiled binary: a platformed gem pinned to a single
-  # Ruby minor series. These are content-addressed (name-version-<sha>) at build
-  # time so multiple per-Ruby builds of the same version+platform can coexist.
-  # Fat binaries (spanning many Ruby minors) and source gems are not.
+  # Ruby ABI. These are content-addressed (name-version-<sha>) at build time so
+  # multiple per-Ruby builds of the same version+platform can coexist. Fat
+  # binaries (spanning many Ruby ABIs) and source gems are not.
 
   def content_addressable?
     return false if platform.nil? || platform == Gem::Platform::RUBY
 
-    !content_addressable_ruby_minor.nil?
+    !content_addressable_ruby_abi.nil?
   end
 
   ##
   # The single "MAJOR.MINOR" Ruby series this gem targets, or nil if it spans
   # more than one. Recognizes both `~> X.Y.Z` and the `>= X.Y, < X.(Y+1).dev`
-  # range rake-compiler emits for single-Ruby native gems.
+  # range rake-compiler emits for single-ABI native gems.
 
-  def content_addressable_ruby_minor
+  def content_addressable_ruby_abi
     reqs = required_ruby_version.requirements
     return nil if reqs.empty?
 

--- a/lib/rubygems/specification.rb
+++ b/lib/rubygems/specification.rb
@@ -2416,7 +2416,10 @@ class Gem::Specification < Gem::BasicSpecification
   def to_ruby
     result = []
     result << "# -*- encoding: utf-8 -*-"
-    result << "#{Gem::StubSpecification::PREFIX}#{name} #{version} #{platform} #{raw_require_paths.join("\0")}"
+    stub = "#{Gem::StubSpecification::PREFIX}#{name} #{version} #{platform} #{raw_require_paths.join("\0")}"
+    # content-addressable binaries carry the sha so the stub can rebuild full_name
+    stub += " #{content_address}" if content_address
+    result << stub
     result << "#{Gem::StubSpecification::PREFIX}#{extensions.join "\0"}" unless
       extensions.empty?
     result << nil

--- a/lib/rubygems/stub_specification.rb
+++ b/lib/rubygems/stub_specification.rb
@@ -14,7 +14,7 @@ class Gem::StubSpecification < Gem::BasicSpecification
 
   class StubLine # :nodoc: all
     attr_reader :name, :version, :platform, :require_paths, :extensions,
-                :full_name
+                :full_name, :content_address
 
     NO_EXTENSIONS = [].freeze
 
@@ -34,7 +34,10 @@ class Gem::StubSpecification < Gem::BasicSpecification
     }.freeze
 
     def initialize(data, extensions)
-      parts          = data[PREFIX.length..-1].split(" ", 4)
+      # Fields: name version platform require_paths [content_address]
+      # The trailing content_address is present only for content-addressable
+      # ("skinny") binaries; old stubs have 4 fields and parse it as nil.
+      parts          = data[PREFIX.length..-1].split(" ", 5)
       @name          = -parts[0]
       @version       = if Gem::Version.correct?(parts[1])
         Gem::Version.new(parts[1])
@@ -42,15 +45,18 @@ class Gem::StubSpecification < Gem::BasicSpecification
         Gem::Version.new(0)
       end
 
-      @platform      = Gem::Platform.new parts[2]
-      @extensions    = extensions
-      @full_name     = if platform == Gem::Platform::RUBY
+      @platform         = Gem::Platform.new parts[2]
+      @extensions       = extensions
+      @content_address  = parts[4]
+      @full_name        = if @content_address
+        "#{name}-#{version}-#{@content_address}"
+      elsif platform == Gem::Platform::RUBY
         "#{name}-#{version}"
       else
         "#{name}-#{version}-#{platform}"
       end
 
-      path_list = parts.last
+      path_list = parts[3]
       @require_paths = REQUIRE_PATH_LIST[path_list] || path_list.split("\0").map! do |x|
         REQUIRE_PATHS[x] || x
       end
@@ -178,6 +184,10 @@ class Gem::StubSpecification < Gem::BasicSpecification
 
   def full_name
     data.full_name
+  end
+
+  def content_address
+    data.content_address
   end
 
   ##

--- a/lib/rubygems/stub_specification.rb
+++ b/lib/rubygems/stub_specification.rb
@@ -196,6 +196,14 @@ class Gem::StubSpecification < Gem::BasicSpecification
   def spec
     @spec ||= loaded_spec if @data
     @spec ||= Gem::Specification.load(loaded_from)
+    # The content address lives on the stub line, not in the gemspec body, so the
+    # freshly-evalled full spec wouldn't know its content-addressed full_name
+    # (and would compute name-version-platform paths that don't exist on disk).
+    # Carry it over from the stub.
+    if @spec && !@spec.content_address && (ca = content_address) && !ca.empty?
+      @spec.content_address = ca
+    end
+    @spec
   end
   alias_method :to_spec, :spec
 


### PR DESCRIPTION
## Summary

Adds support for **content-addressable precompiled binaries** to RubyGems and
Bundler. A "skinny" binary is a platformed gem pinned to a single Ruby minor
(e.g. `required_ruby_version = "~> 3.3.0"`). Today, every per-Ruby build of the
same `name`–`version`–`platform` collides on a single identity
(`name-version-platform`), so a registry can only host one of them.

This PR makes such gems **built, named, installed, and resolved by content
address** — `name-version-<sha>`, where `<sha> = sha256(.gem)[0, 10]` — so
multiple per-Ruby builds of the same version+platform can coexist, and the
correct one is selected at resolve time based on the running Ruby.

## Design

- **Identity:** `content_address = sha256(.gem)[0, 10]`. Computed from bytes, so
  the builder, the installer, and a registry all derive the same value without
  coordination.
- **"Skinny" detection:** a gem is content-addressable when it is **platformed
  and pinned to a single Ruby minor** (`~> 3.3.0`, or rake-compiler's
  `>= 3.3, < 3.4.dev`). Fat binaries (`>= 2.7, < 4.1.dev`) and pure-Ruby gems are
  not content-addressable and are untouched.
- **Build:** `Gem::Package.build` renames a skinny gem from
  `name-version-platform.gem` to `name-version-<sha>.gem`. The filename is not
  part of the hashed content, so renaming after building is safe.
- **Install:** the gem installs under `gems/name-version-<sha>/`, and the
  10-char sha is recorded in the stub line so `full_name` reconstructs the
  content-addressed name offline (no `.gem` bytes required).
- **Lockfile:** stays portable. The lock records `name (version-platform)`;
  Bundler bridges that back to the on-disk `name-version-<sha>` at install time.
- **Compact index (remote):** the per-gem info line carries the content address
  in the **version token's platform slot** and the **real** platform in a
  `platform:` requirement token:
  ```
  1.0.0-<sha> |checksum:<sha256-hex>,ruby:<req>,platform:<real-platform>
  ```
  The `<sha>` slot becomes the gem's `full_name` (and download path
  `/gems/name-version-<sha>.gem`); the `platform:` token is used for
  compatibility matching.
- **Resolution preference:** when a skinny binary compatible with the running
  Ruby exists, Bundler prefers it **exclusively**; otherwise it falls back to
  the fat/ruby variant so a usable binary is never stranded. Per-minor `~>`
  ranges are disjoint, so at most one skinny qualifies (no skinny-vs-skinny
  tie-break needed).

## Changes

### RubyGems core

- **`lib/rubygems/specification.rb`** — `content_addressable?` /
  `content_addressable_ruby_minor` (skinny detection, handling both `~> X.Y.0`
  and rake-compiler's `>= X.Y, < X.(Y+1).dev`); `to_ruby` writes the content
  address into the stub line.
- **`lib/rubygems/package.rb`** — `Gem::Package.build` renames skinny gems to
  `name-version-<sha>.gem`.
- **`lib/rubygems/package_task.rb`** — moves the (renamed) built file to the
  package dir.
- **`lib/rubygems/basic_specification.rb`** — `content_address` accessor;
  `full_name` returns `name-version-<sha>` when a content address is present.
- **`lib/rubygems/stub_specification.rb`** — reads the optional 5th stub-line
  field (the sha); `full_name` reconstructs the content-addressed name;
  `to_spec` carries the content address onto the loaded full spec (the body has
  no sha, only the stub line does).
- **`lib/rubygems/installer.rb`** — `assign_content_address` derives the sha
  from the gem's bytes before any path is computed, so the install dir and stub
  are content-addressed.
- **`lib/rubygems/platform.rb`** — `Gem::Platform` preserves a 10-hex-char
  content-address token verbatim instead of normalizing it to the bogus
  platform `"unknown"`; round-trips through `to_a`/`to_s`/`==`.

### Bundler

- **`endpoint_specification.rb`** — parses the compact-index `platform:` token
  into `real_platform`; `content_addressable?`; `installable_on_platform?` uses
  the real platform (since `@platform` holds the sha).
- **`match_platform.rb`** — `usable_skinny?` and the "prefer a Ruby-compatible
  skinny exclusively, else fall back to fat" selection.
- **`lazy_specification.rb`** — carries `real_platform`/`content_address`;
  content-addressed `full_name`; on a `--local` exact-match miss, retries by
  `name+version` so the portable lockfile entry resolves to the on-disk
  `name-version-<sha>` gem.
- **`stub_specification.rb`** — delegates `full_name`/`content_address` to the
  underlying RubyGems stub.
- **`compact_index_client.rb`, `compact_index_client/cache.rb`,
  `fetcher/compact_index.rb`** — negotiate a v2 compact-index namespace
  (`/v2/versions`, `/v2/info/<gem>`) so old clients never see content-addressable
  entries, with transparent fallback to v1.

### Tests / tooling

- **`dev/content-addressable-test/`** — self-contained, native end-to-end tests
  (no containers, no rubygems.org): a tiny native demo gem, a dependency-free
  fake compact-index server, and `test_local.sh` / `test_remote.sh` with a
  README documenting what's covered and how to run.

## Testing

Verified natively on macOS (`arm64-darwin`):

- **Build:** `rake native gem` → `hola-1.0.0-<sha>.gem`.
- **`--local`:** `gem install` → `gems/hola-1.0.0-<sha>/` with the sha in the
  stub; `bundle install --local`, `bundle exec require`, idempotent re-install
  (lockfile round-trip), and `bundle list` all work; `gem uninstall` removes the
  content-addressed dir. No regression for normal gems.
- **Remote:** against a fake compact-index server, Bundler probes
  `/v2/versions`, parses the content-addressed info line, downloads
  `/gems/hola-1.0.0-<sha>.gem`, installs, and `require` works.

Run:
```bash
cd dev/content-addressable-test
./test_local.sh
./test_remote.sh
```