### PR TITLE
Content addressable gems POC

### DIFF
--- a/bundler/lib/bundler/endpoint_specification.rb
+++ b/bundler/lib/bundler/endpoint_specification.rb
@@ -5,7 +5,7 @@ module Bundler
   class EndpointSpecification < Gem::Specification
     include MatchRemoteMetadata
 
-    attr_reader :name, :version, :platform, :checksum, :created_at
+    attr_reader :name, :version, :platform, :checksum, :created_at, :platform_requirement
     attr_writer :dependencies
     attr_accessor :remote, :locked_platform
 
@@ -21,11 +21,37 @@ module Bundler
       @loaded_from          = nil
       @remote_specification = nil
       @locked_platform = nil
+      @platform_requirement = nil
 
       parse_metadata(metadata)
     end
 
+    # A content-addressable ("skinny") binary: the version token carries a SHA
+    # prefix instead of a platform, and the real platform is supplied via the
+    # compact index `platform:` requirement.
+    def content_addressable?
+      !@platform_requirement.nil?
+    end
+
+    # The version suffix (SHA prefix) carried in the version token's platform
+    # slot, e.g. "9f3c1a2b". Used to reconstruct the download/full name. nil for
+    # ordinary gems, whose @platform is a real Gem::Platform or the "ruby" string.
+    def version_suffix
+      @platform.version_suffix if @platform.is_a?(Gem::Platform)
+    end
+
+    # For content-addressable specs, platform matching must use the platform
+    # requirement from metadata, not the SHA prefix stored in @platform.
+    def installable_on_platform?(target_platform)
+      return super unless content_addressable?
+
+      target_platform.nil? ||
+        target_platform == Gem::Platform::RUBY ||
+        @platform_requirement === Gem::Platform.new(target_platform)
+    end
+
     def insecurely_materialized?
+      return false if content_addressable?
       @locked_platform.to_s != @platform.to_s
     end
 
@@ -162,6 +188,10 @@ module Bundler
           @required_rubygems_version = Gem::Requirement.new(v)
         when "ruby"
           @required_ruby_version = Gem::Requirement.new(v)
+        when "platform"
+          # e.g. v == ["= x86_64-linux-musl"]; strip the requirement operator.
+          platform_string = Array(v).last.to_s.sub(/\A\s*=?\s*/, "")
+          @platform_requirement = Gem::Platform.new(platform_string) unless platform_string.empty?
         when "created_at"
           value = v.is_a?(Array) ? v.last : v
           if value.is_a?(String)

--- a/bundler/lib/bundler/lazy_specification.rb
+++ b/bundler/lib/bundler/lazy_specification.rb
@@ -9,7 +9,7 @@ module Bundler
     include ForcePlatform
 
     attr_reader :name, :version, :platform, :materialization
-    attr_accessor :source, :remote, :force_ruby_platform, :dependencies, :required_ruby_version, :required_rubygems_version, :overrides
+    attr_accessor :source, :remote, :force_ruby_platform, :dependencies, :required_ruby_version, :required_rubygems_version, :overrides, :platform_requirement, :version_suffix
 
     #
     # For backwards compatibility with existing lockfiles, if the most specific
@@ -31,7 +31,23 @@ module Bundler
       lazy_spec.required_ruby_version = s.required_ruby_version
       lazy_spec.required_rubygems_version = s.required_rubygems_version
       lazy_spec.overrides = s.overrides if s.is_a?(LazySpecification)
+      lazy_spec.platform_requirement = s.platform_requirement if s.respond_to?(:platform_requirement)
+      lazy_spec.version_suffix = s.version_suffix if s.respond_to?(:version_suffix)
       lazy_spec
+    end
+
+    def content_addressable?
+      !@platform_requirement.nil?
+    end
+
+    # Match using the platform requirement from metadata when content-addressable,
+    # since @platform holds the SHA prefix rather than a real platform.
+    def installable_on_platform?(target_platform)
+      return super unless content_addressable?
+
+      target_platform.nil? ||
+        target_platform == Gem::Platform::RUBY ||
+        @platform_requirement === Gem::Platform.new(target_platform)
     end
 
     def initialize(name, version, platform, source = nil, **materialization_options)
@@ -64,7 +80,9 @@ module Bundler
     end
 
     def full_name
-      @full_name ||= if platform == Gem::Platform::RUBY
+      @full_name ||= if @version_suffix
+        "#{@name}-#{@version}-#{@version_suffix}"
+      elsif platform == Gem::Platform::RUBY
         "#{@name}-#{@version}"
       else
         "#{@name}-#{@version}-#{platform}"
@@ -140,6 +158,17 @@ module Bundler
 
       if use_exact_resolved_specifications?
         spec = materialize(self) {|specs| choose_compatible(specs, fallback_to_non_installable: false) }
+
+        # The exact locked full_name wasn't found in the index (materialize returns
+        # self). This happens for content-addressable gems: the installed full_name
+        # is name-version-<sha>, while the lockfile pins the portable
+        # name-version-platform. Retry by name+version and let platform/ruby
+        # selection pick the right binary.
+        if spec.equal?(self)
+          by_name = materialize([name, version]) {|specs| resolve_best_platform(specs) }
+          return by_name unless by_name.nil? || by_name.equal?(self)
+        end
+
         return spec if spec
 
         # Exact spec is incompatible; in frozen mode, try to find a compatible platform variant

--- a/bundler/lib/bundler/match_platform.rb
+++ b/bundler/lib/bundler/match_platform.rb
@@ -22,8 +22,33 @@ module Bundler
       Gem::Platform.sort_best_platform_match(matching, local)
     end
 
+    def self.content_addressable?(spec)
+      spec.respond_to?(:content_addressable?) && spec.content_addressable?
+    end
+
+    # A skinny binary targets exactly one Ruby minor (e.g. `~> 3.2.0`). Those
+    # ranges are disjoint, so at most one skinny variant per (gem, version,
+    # platform) is compatible with the running Ruby. Only a Ruby-compatible
+    # skinny may displace the fat/ruby fallback.
+    def self.usable_skinny?(spec)
+      return false unless content_addressable?(spec)
+
+      req = spec.required_ruby_version
+      req.nil? || req.none? || req.satisfied_by?(Gem.ruby_version)
+    end
+
     def self.select_all_platform_match(specs, platform, force_ruby: false, prefer_locked: false)
       matching = specs.select {|spec| spec.installable_on_platform?(force_ruby ? Gem::Platform::RUBY : platform) }
+
+      # Prefer the skinny (content-addressable) binary: when a skinny variant
+      # compatible with the running Ruby exists, choose it exclusively. If no
+      # skinny matches this Ruby, keep the fat/ruby variants as a fallback so we
+      # never strand a usable binary. Because per-minor `~>` ranges are disjoint,
+      # at most one skinny qualifies -- no skinny-vs-skinny tie-break is needed.
+      unless force_ruby
+        skinny = matching.select {|spec| usable_skinny?(spec) }
+        matching = skinny if skinny.any?
+      end
 
       specs.each(&:force_ruby_platform!) if force_ruby
 

--- a/bundler/lib/bundler/stub_specification.rb
+++ b/bundler/lib/bundler/stub_specification.rb
@@ -13,6 +13,19 @@ module Bundler
       false
     end
 
+    # Delegate to the underlying RubyGems stub so content-addressable binaries
+    # use their content-addressed name (name-version-<sha>), matching the install
+    # directory, rather than recomputing name-version-platform.
+    def full_name
+      stub.full_name
+    end
+
+    # The version suffix lives on the stub line, not in the gemspec body, so read
+    # it from the RubyGems stub rather than method_missing'ing to the full spec.
+    def version_suffix
+      stub.version_suffix
+    end
+
     attr_reader :checksum
     attr_accessor :stub, :ignored
 

--- a/dev/content-addressable-v1-demo/README.md
+++ b/dev/content-addressable-v1-demo/README.md
@@ -1,0 +1,146 @@
+# Content-addressable gems in the **v1** compact index — resolution proof
+
+This prototype implements the proposal where
+content-addressable ("skinny") gems are **directly in the v1 compact index**
+, gated by a `rubygems:>=` requirement so that:
+
+- **old clients ignore** the skinny rows (they don't satisfy `rubygems:>=`), and
+- **new clients process** them, match on the `platform:` metadata token, and
+  download the content-addressed `name-version-<sha>.gem`.
+
+A skinny `/info/hola` entry looks like (content-addressable rows last):
+
+```
+---
+1.0.0                      |checksum:…,ruby:>= 3.1,rubygems:>= 3.3.22
+1.0.0-x86_64-linux         |checksum:…,ruby:>= 3.1
+1.0.0-ef716ba7a6           |checksum:…,ruby:~> 4.0.0,rubygems:>= 4.1.0.dev,platform:= x86_64-linux
+```
+
+- The version slot's "platform" (`ef716ba7a6`) is the **content address** =
+  `sha256(.gem)[0,10]`. It becomes the gem's `full_name` and download path.
+- The `platform:` **metadata token** carries the real platform, used for
+  compatibility matching.
+- `rubygems:>= 4.1.0.dev` is the gate: this is the RubyGems version
+  content-addressable support is assumed to ship in.
+
+## Run it
+
+```bash
+# 1. Resolution proof — no compiler/network needed (pure parser + selection)
+./dev/content-addressable-v1-demo/test_resolution.sh
+
+# 2. Local install path — build a native gem, gem install, bundle install --local
+./dev/content-addressable-v1-demo/test_local.sh
+
+# 3. Remote install path — serve a v1 index from a fake server, bundle install
+PORT=8920 ./dev/content-addressable-v1-demo/test_remote_v1.sh
+
+# 4. Old-client compatibility — stock RubyGems/Bundler ignores the skinny rows
+PORT=8920 ./dev/content-addressable-v1-demo/test_remote_v1_oldclient.sh
+```
+
+Each ends with `ALL GOOD`. `test_local.sh` / `test_remote_v1.sh` build a tiny
+native gem (`demo/`) and need a C toolchain plus a one-time `rake-compiler`
+install. They use the Ruby on your `PATH` (the demo gemspec pins `~>` that
+Ruby's minor, so it is "skinny" for whatever Ruby you run); override with
+`RUBY_PREFIX=/opt/rubies/X`.
+
+## What it proves
+
+### Resolution (`test_resolution.sh`)
+
+For a single `hola 1.0.0` published as **source**, **fat** (regular
+precompiled), and **skinny** (content-addressable) variants, using the *real*
+client code (`Gem::Resolver::APISet::GemParser`, `Bundler::EndpointSpecification`
+built exactly like `Bundler::Fetcher#specs`, and
+`Bundler::MatchPlatform.select_best_platform_match`):
+
+1. **New client picks the skinny one** and its download name reconstructs to
+   `hola-1.0.0-ef716ba7a6.gem`.
+2. **Old client ignores the skinny rows.** The `rubygems:>= 4.1.0.dev`
+   requirement is not satisfied by a pre-CA RubyGems (e.g. 3.5.0), so
+   `matches_current_rubygems?` is false and the row is dropped; the old client
+   falls back to the fat binary.
+
+### Install paths (`test_local.sh`, `test_remote_v1.sh`)
+
+These exercise the install machinery ported from
+[PR #168](https://github.com/Shopify/rubygems/pull/168) on top of the v1 branch:
+
+- **Build:** `rake native gem` content-addresses the skinny gem, renaming
+  `hola-1.0.0-<platform>.gem` → `hola-1.0.0-<sha>.gem` in `Gem::Package.build`.
+- **`--local`:** `gem install` installs under `gems/hola-1.0.0-<sha>/` and
+  records the sha in the stub line (`# stub: hola 1.0.0 <platform> lib <sha>`),
+  so `full_name` reconstructs the content-addressed name offline.
+  `bundle install --local` resolves it (the lockfile stays portable —
+  `hola (1.0.0-<platform>)` — and Bundler bridges back to the on-disk
+  `name-version-<sha>` gem), `bundle exec require` + `bundle list` work, and
+  re-install is idempotent.
+- **Remote (v1):** Bundler fetches `/versions` and `/info/hola` (unprefixed —
+  **no `/v2/` endpoint**), selects the skinny variant, downloads
+  `/gems/hola-1.0.0-<sha>.gem`, installs it, and `require` works.
+
+### Old-client compatibility (`test_remote_v1_oldclient.sh`)
+
+The most important backwards-compat guarantee: a **new publisher** serving
+content-addressable gems must not break **old consumers**. This test serves a
+real fat binary plus a gated skinny row, then installs with two clients against
+the same v1 index:
+
+- **Old client** (the stock RubyGems/Bundler on `PATH` — here 4.0.10, older than
+  the `4.1.0.dev` gate and without the patches): ignores the skinny row
+  (`rubygems:>= 4.1.0.dev` is unsatisfied, and the `<sha>` token doesn't match
+  the local platform anyway), installs `hola-1.0.0-<platform>.gem`, and
+  `require` works. It **never requests** the skinny `.gem`, and doesn't choke on
+  the `<sha>` version token or the `platform:` metadata token.
+- **New client** (patched): selects and downloads the skinny
+  `hola-1.0.0-<sha>.gem`.
+
+The server request log shows exactly which `.gem` each client fetched, proving
+the split.
+
+## Client changes that make this work (vs. master)
+
+All on top of `master`; **no v2 endpoint involved**. Naming convention on this
+branch: the sha identity is `version_suffix`; the real platform from metadata is
+`platform_requirement`.
+
+### RubyGems core (build + install)
+
+| File | Change |
+| --- | --- |
+| `lib/rubygems/platform.rb` | Preserve a 10-hex-char **version suffix** verbatim instead of normalizing it to `os="unknown"`. Kept in its own `version_suffix` field; `==`/`hash`/`===` treat it as an exact-match token. |
+| `lib/rubygems/specification.rb` | `content_addressable?` / `content_addressable_ruby_abi` (skinny detection: `~> X.Y.Z` and rake-compiler's `>= X.Y, < X.(Y+1).dev`); `to_ruby` writes the version suffix into the stub line. |
+| `lib/rubygems/package.rb` | `Gem::Package.build` renames skinny gems to `name-version-<sha>.gem`. |
+| `lib/rubygems/package_task.rb` | Move the (renamed) built file to the package dir. |
+| `lib/rubygems/basic_specification.rb` | `version_suffix` accessor; `full_name` returns `name-version-<sha>` when set. |
+| `lib/rubygems/stub_specification.rb` | Read the optional 5th stub-line field (the sha); `full_name` reconstructs the content-addressed name; `to_spec` carries the suffix onto the loaded full spec. |
+| `lib/rubygems/installer.rb` | `assign_version_suffix` derives the sha from the gem's bytes before any path is computed. |
+
+### Bundler (resolution + install bridge)
+
+| File | Change |
+| --- | --- |
+| `bundler/lib/bundler/endpoint_specification.rb` | Parse the `platform:` metadata token into `platform_requirement`; add `content_addressable?`, `version_suffix`, and a platform match that uses the platform requirement. |
+| `bundler/lib/bundler/match_platform.rb` | When a skinny variant compatible with the running Ruby exists, prefer it **exclusively** over fat/source (per-Ruby-minor `~>` ranges are disjoint, so at most one qualifies). |
+| `bundler/lib/bundler/lazy_specification.rb` | Carry `platform_requirement`/`version_suffix`; reconstruct `full_name` as `name-version-<sha>`; on a `--local` exact-match miss, retry by name+version so the portable lockfile entry resolves to the on-disk `name-version-<sha>` gem. |
+| `bundler/lib/bundler/stub_specification.rb` | Delegate `full_name`/`version_suffix` to the underlying RubyGems stub. |
+
+## Differences from PR #168
+
+- **No v2 endpoint.** PR #168 negotiates a `/v2/` compact-index namespace to hide
+  content-addressable entries from old clients. This branch keeps everything in
+  the **v1** index and hides skinny rows from old clients with a `rubygems:>=`
+  gate instead, so `compact_index_client.rb` / `cache.rb` /
+  `fetcher/compact_index.rb` are left untouched.
+- **Naming.** PR #168 uses `content_address` / `real_platform`; this branch uses
+  `version_suffix` / `platform_requirement`.
+
+## Known nuance
+
+On the **remote** path the gem currently installs into
+`gems/hola-1.0.0-<real-platform>/`, whereas the **`--local`** path installs into
+`gems/hola-1.0.0-<sha>/`. Both are internally consistent and work for a single
+active Ruby, but they disagree on the on-disk directory name (same nuance noted
+in PR #168).

--- a/dev/content-addressable-v1-demo/demo/.gitignore
+++ b/dev/content-addressable-v1-demo/demo/.gitignore
@@ -1,0 +1,5 @@
+/tmp/
+/pkg/
+/lib/hola/*.bundle
+/lib/hola/*.so
+*.gem

--- a/dev/content-addressable-v1-demo/demo/Rakefile
+++ b/dev/content-addressable-v1-demo/demo/Rakefile
@@ -1,0 +1,5 @@
+require "rake/extensiontask"
+spec = Gem::Specification.load("hola.gemspec")
+Rake::ExtensionTask.new("hola", spec) do |ext|
+  ext.lib_dir = "lib/hola"
+end

--- a/dev/content-addressable-v1-demo/demo/ext/hola/extconf.rb
+++ b/dev/content-addressable-v1-demo/demo/ext/hola/extconf.rb
@@ -1,0 +1,2 @@
+require "mkmf"
+create_makefile("hola/hola")

--- a/dev/content-addressable-v1-demo/demo/ext/hola/hola.c
+++ b/dev/content-addressable-v1-demo/demo/ext/hola/hola.c
@@ -1,0 +1,9 @@
+#include <ruby.h>
+
+static VALUE hola(VALUE self) {
+  return rb_str_new_cstr("hola from native");
+}
+
+void Init_hola(void) {
+  rb_define_global_function("hola", hola, 0);
+}

--- a/dev/content-addressable-v1-demo/demo/hola.gemspec
+++ b/dev/content-addressable-v1-demo/demo/hola.gemspec
@@ -1,0 +1,13 @@
+Gem::Specification.new do |s|
+  s.name        = "hola"
+  s.version     = "1.0.0"
+  s.summary     = "content-addressable native gem demo"
+  s.authors     = ["poc"]
+  s.files       = Dir["lib/**/*.rb"] + Dir["ext/**/*"]
+  s.extensions  = ["ext/hola/extconf.rb"]
+  # Pin to a single Ruby ABI (the Ruby building this gem) so it is a "skinny"
+  # binary -> content-addressable. Computed at build time so the demo is skinny
+  # for whatever Ruby you run it with, not just 3.3.
+  minor = RUBY_VERSION.split(".").first(2).join(".")
+  s.required_ruby_version = "~> #{minor}.0"
+end

--- a/dev/content-addressable-v1-demo/demo/lib/hola.rb
+++ b/dev/content-addressable-v1-demo/demo/lib/hola.rb
@@ -1,0 +1,1 @@
+require "hola/hola"

--- a/dev/content-addressable-v1-demo/fake_compact_index.rb
+++ b/dev/content-addressable-v1-demo/fake_compact_index.rb
@@ -1,0 +1,60 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+#
+# Minimal compact-index gem server for testing content-addressable ("skinny")
+# binaries end-to-end over the **v1** compact index, with no external deps
+# (raw TCPServer, threaded).
+#
+# Serves a directory tree as static files over HTTP/1.1:
+#   GET /versions       -> <root>/versions
+#   GET /info/<gem>     -> <root>/info/<gem>
+#   GET /gems/<file>.gem -> <root>/gems/<file>.gem
+#
+# Always returns the full body (200); ignores Range (Bundler's compact-index
+# updater handles a full response even when it sent a Range header). Logs every
+# request to stderr so you can see exactly what Bundler asks for.
+#
+# Usage: ruby fake_compact_index.rb <root_dir> <port>
+
+require "socket"
+
+root = File.expand_path(ARGV[0] || ".")
+port = Integer(ARGV[1] || "8899")
+
+server = TCPServer.new("127.0.0.1", port)
+warn "[fake-index] serving #{root} on http://127.0.0.1:#{port}"
+
+loop do
+  conn = server.accept
+  Thread.new(conn) do |c|
+    begin
+      request_line = c.gets
+      next unless request_line
+      method, path, = request_line.split(" ")
+      # drain headers
+      while (line = c.gets) && line != "\r\n"; end
+
+      clean = path.split("?", 2).first.to_s
+      file = File.join(root, clean)
+      warn "[fake-index] #{method} #{clean} -> #{File.exist?(file) ? "200" : "404"}"
+
+      if File.file?(file)
+        body = File.binread(file)
+        ctype = clean.end_with?(".gem") ? "application/octet-stream" : "text/plain"
+        head = +"HTTP/1.1 200 OK\r\n"
+        head << "Content-Type: #{ctype}\r\n"
+        head << "Content-Length: #{body.bytesize}\r\n"
+        head << "Accept-Ranges: none\r\n"
+        head << "Connection: close\r\n\r\n"
+        c.write(head)
+        c.write(body) unless method == "HEAD"
+      else
+        c.write("HTTP/1.1 404 Not Found\r\nContent-Length: 0\r\nConnection: close\r\n\r\n")
+      end
+    rescue => e
+      warn "[fake-index] error: #{e.class}: #{e.message}"
+    ensure
+      c.close rescue nil
+    end
+  end
+end

--- a/dev/content-addressable-v1-demo/prove_resolution.rb
+++ b/dev/content-addressable-v1-demo/prove_resolution.rb
@@ -1,0 +1,130 @@
+# frozen_string_literal: true
+
+# Proof: content-addressable ("skinny") gems encoded in the **v1** compact index
+# are (a) chosen by a new client over the fat and source variants, and (b)
+# ignored by old clients via the `rubygems:` requirement gate.
+#
+# This deliberately uses the *real* client code paths -- the host RubyGems
+# compact-index line parser (Gem::Resolver::APISet::GemParser), the real
+# Bundler::EndpointSpecification (built exactly like Bundler::Fetcher#specs
+# does), and the real Bundler::MatchPlatform platform selection -- so the
+# demo proves the production behaviour, not a reimplementation.
+#
+# Run with the patched RubyGems + Bundler from this checkout:
+#
+#   ruby --disable-gems -Ilib -rrubygems -Ibundler/lib \
+#     dev/content-addressable-v1-demo/prove_resolution.rb
+#
+# (test_resolution.sh wires that up for you.)
+
+require "bundler"
+require "bundler/endpoint_specification"
+require "bundler/match_platform"
+require "rubygems/resolver"
+
+# The RubyGems version at which content-addressable support ships. New clients
+# satisfy this; old clients do not and therefore drop the skinny rows.
+CA_SUPPORTED_FROM = "4.1.0.dev"
+
+LOCAL = Gem::Platform.local                       # e.g. arm64-darwin-24 / x86_64-linux
+RUBY_MINOR = RUBY_VERSION.split(".").first(2).join(".") # e.g. "4.0"
+SHA10 = "ef716ba7a6"                              # sha256(.gem)[0,10]
+
+# A single gem `hola 1.0.0` published in three shapes, exactly as it would
+# appear in the v1 `/info/hola` file. Order mirrors the Slack proposal: the
+# content-addressable rows come last and carry `rubygems:>=` + `platform:`.
+INFO = <<~INFO
+  ---
+  1.0.0 |checksum:#{"a" * 64},ruby:>= 3.1,rubygems:>= 3.3.22
+  1.0.0-#{LOCAL} |checksum:#{"b" * 64},ruby:>= 3.1
+  1.0.0-#{SHA10} |checksum:#{"c" * 64},ruby:~> #{RUBY_MINOR}.0,rubygems:>= #{CA_SUPPORTED_FROM},platform:= #{LOCAL}
+INFO
+
+# Minimal spec fetcher stand-in: EndpointSpecification only needs #uri (for
+# checksum attribution). #fetch_spec is never reached in this offline demo.
+FakeFetcher = Struct.new(:uri) do
+  def fetch_spec(*) = raise("network access not expected in this demo")
+end
+FETCHER = FakeFetcher.new("https://example.test")
+
+# Build EndpointSpecifications from the info file using the real parser, the
+# same way Bundler::Fetcher#specs does (name, version, platform, deps, metadata).
+def build_specs(info)
+  parser = Gem::Resolver::APISet::GemParser.new
+  lines = info.split("\n")
+  body = lines[(lines.index("---") + 1)..]
+  body.map do |line|
+    version, platform, deps, reqs = parser.parse(line)
+    Bundler::EndpointSpecification.new("hola", version, platform, FETCHER, deps, reqs)
+  end
+end
+
+def describe(spec)
+  kind =
+    if spec.content_addressable? then "SKINNY (content-addressable)"
+    elsif spec.platform == Gem::Platform::RUBY then "source  (ruby platform)"
+    else "fat     (precompiled platform)"
+    end
+  "#{spec.full_name.ljust(28)} -> #{kind}"
+end
+
+specs = build_specs(INFO)
+
+puts "Running RubyGems #{Gem::VERSION}, Ruby #{RUBY_VERSION}, platform #{LOCAL}"
+puts
+puts "Parsed v1 /info/hola into #{specs.size} candidate specs:"
+specs.each {|s| puts "  #{describe(s)}" }
+puts
+
+# ---------------------------------------------------------------------------
+# Part 1: a NEW client (this RubyGems) picks the skinny variant.
+# ---------------------------------------------------------------------------
+chosen = Bundler::MatchPlatform.select_best_platform_match(specs, LOCAL)
+raise "expected exactly one winner, got #{chosen.size}" unless chosen.size == 1
+winner = chosen.first
+
+puts "[new client] select_best_platform_match(#{LOCAL}) chose:"
+puts "  #{describe(winner)}"
+puts "  download name: #{winner.full_name}.gem  (reconstructed from version + sha)"
+puts
+
+unless winner.content_addressable?
+  abort "FAIL: expected the skinny (content-addressable) gem to be chosen"
+end
+
+# ---------------------------------------------------------------------------
+# Part 2: an OLD client drops the skinny rows via the `rubygems:` gate.
+# `matches_current_rubygems?` is exactly the lever the resolver uses to
+# exclude metadata-incompatible candidates. We simulate an old client by
+# checking the gate against a pre-CA RubyGems version.
+# ---------------------------------------------------------------------------
+old_rubygems = Gem::Version.new("3.5.0")
+skinny = specs.find(&:content_addressable?)
+gate = skinny.required_rubygems_version
+old_client_keeps_skinny = gate.satisfied_by?(old_rubygems)
+new_client_keeps_skinny = skinny.matches_current_rubygems?
+
+puts "[gate] skinny row declares rubygems:#{gate}"
+puts "  old client (RubyGems #{old_rubygems}): keeps skinny? #{old_client_keeps_skinny}  -> ignores it"
+puts "  new client (RubyGems #{Gem::VERSION}): keeps skinny? #{new_client_keeps_skinny}  -> processes it"
+puts
+
+if old_client_keeps_skinny
+  abort "FAIL: an old client should NOT satisfy the rubygems gate"
+end
+unless new_client_keeps_skinny
+  abort "FAIL: this (new) client should satisfy the rubygems gate"
+end
+
+# What an OLD client would actually resolve: drop gated-out rows first, then
+# run the same platform selection. It must fall back to the fat binary.
+old_visible = specs.reject {|s| !s.required_rubygems_version.satisfied_by?(old_rubygems) }
+old_winner = Bundler::MatchPlatform.select_best_platform_match(old_visible, LOCAL).first
+puts "[old client] after dropping gated rows, select_best_platform_match chose:"
+puts "  #{describe(old_winner)}"
+if old_winner.content_addressable?
+  abort "FAIL: old client should fall back to the fat binary, not the skinny one"
+end
+puts
+
+puts "ALL GOOD: new clients choose the skinny gem; old clients fall back to fat."

--- a/dev/content-addressable-v1-demo/test_local.sh
+++ b/dev/content-addressable-v1-demo/test_local.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+#
+# End-to-end test of content-addressable ("skinny") precompiled gems over the
+# LOCAL path (bundle install --local), natively. No containers, no network
+# except the one-time rake-compiler install.
+#
+# Proves the install paths from PR #168 on top of the v1 branch:
+#   - `rake native gem` builds a skinny gem and renames it to name-version-<sha>.gem
+#   - `gem install` installs it under gems/name-version-<sha>/ with the sha in the stub
+#   - `bundle install --local` resolves the content-addressed gem (lockfile round-trip)
+#   - `bundle exec require` + `bundle list` work; re-install is idempotent
+#
+# Uses the Ruby on your PATH (the demo gemspec pins ~> that Ruby's minor, so it
+# is skinny for whatever Ruby you run). Override with RUBY_PREFIX=/opt/rubies/X.
+set -euo pipefail
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+RG="$(cd "$HERE/../.." && pwd)"                    # this rubygems checkout (patched)
+DEMO="$HERE/demo"
+WORK=/tmp/ca-v1-local
+
+if [ -n "${RUBY_PREFIX:-}" ]; then export PATH="$RUBY_PREFIX/bin:$PATH"; fi
+RUBY="$(command -v ruby)"
+export GEM_HOME="$WORK/gemhome" GEM_PATH="$WORK/gemhome"
+BUNDLE="$RUBY -I$RG/bundler/lib $RG/bundler/exe/bundle"
+
+rm -rf "$WORK"; mkdir -p "$WORK/gemhome" "$WORK/app"
+echo "ruby: $($RUBY -e 'print RUBY_VERSION, " ", RUBY_PLATFORM')"
+
+echo "== install released rake-compiler (clean RubyGems) =="
+$RUBY -S gem install rake-compiler --no-document >/dev/null
+
+echo "== build native gem (patched RubyGems loaded over installed gems) =="
+cd "$DEMO"; rm -rf tmp pkg lib/hola/*.bundle lib/hola/*.so
+RUBYOPT="--disable-gems -I$RG/lib -rrubygems" $RUBY -S rake native gem 2>&1 | grep -E "File|Content-addressed"
+GEM=$(ls pkg/hola-1.0.0-*.gem)
+echo "   built       : $(basename "$GEM")"
+
+# everything below uses the patched RubyGems
+export RUBYOPT="--disable-gems -I$RG/lib -rrubygems"
+
+echo "== gem install --local =="
+$RUBY -S gem install --local "$GEM" --no-document | grep -i installed
+echo "   install dir : $(basename "$(ls -d "$GEM_HOME"/gems/hola-*)")"
+echo "   stub line   : $(grep '# stub:' "$GEM_HOME"/specifications/hola-*.gemspec)"
+
+echo "== bundle install --local =="
+cd "$WORK/app"
+printf 'source "http://example.invalid"\ngem "hola"\n' > Gemfile
+$BUNDLE install --local 2>&1 | grep -iE "complete|could not"
+echo "   lockfile    : $(grep -A1 'specs:' Gemfile.lock | tail -1 | xargs)"
+
+echo "== bundle exec require =="
+$BUNDLE exec ruby -e 'require "hola"; puts "   => " + hola'
+
+echo "== bundle install --local AGAIN (idempotent, reads lock) =="
+$BUNDLE install --local 2>&1 | grep -iE "complete|could not"
+
+echo "== bundle list =="
+$BUNDLE list | grep hola
+
+echo "ALL GOOD"

--- a/dev/content-addressable-v1-demo/test_remote_v1.sh
+++ b/dev/content-addressable-v1-demo/test_remote_v1.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+#
+# End-to-end test of a content-addressable ("skinny") gem over the REMOTE path
+# using the **v1** compact index (no /v2/ endpoint). Bundler resolves and
+# downloads it from a fake compact-index server. No rubygems.org, no containers.
+#
+# Proves the full v1 install path:
+#   - /info/hola lists source + fat + skinny rows; the skinny row carries the
+#     content address in the version slot, the real platform in a `platform:`
+#     token, and a `rubygems:>= 4.1.0.dev` gate.
+#   - A new client selects the skinny variant, downloads
+#     /gems/hola-1.0.0-<sha>.gem, installs it, and `require` works.
+#
+# Uses the Ruby on your PATH (demo gemspec pins ~> that Ruby's minor, so it is
+# skinny). Override with RUBY_PREFIX=/opt/rubies/X. Override PORT if 8899 is busy.
+set -euo pipefail
+
+CA_SUPPORTED_FROM="4.1.0.dev"   # the rubygems gate; this build satisfies it
+HERE="$(cd "$(dirname "$0")" && pwd)"
+RG="$(cd "$HERE/../.." && pwd)"
+DEMO="$HERE/demo"
+WORK=/tmp/ca-v1-remote
+PORT="${PORT:-8899}"
+
+if [ -n "${RUBY_PREFIX:-}" ]; then export PATH="$RUBY_PREFIX/bin:$PATH"; fi
+RUBY="$(command -v ruby)"
+export GEM_HOME="$WORK/gemhome" GEM_PATH="$WORK/gemhome"
+BUNDLE="$RUBY -I$RG/bundler/lib $RG/bundler/exe/bundle"
+
+rm -rf "$WORK"; mkdir -p "$WORK/gemhome" "$WORK/app" "$WORK/srv/gems" "$WORK/srv/info"
+echo "ruby: $($RUBY -e 'print RUBY_VERSION, " ", RUBY_PLATFORM')"
+
+echo "== install released rake-compiler + build content-addressed gem =="
+$RUBY -S gem install rake-compiler --no-document >/dev/null
+cd "$DEMO"; rm -rf tmp pkg lib/hola/*.bundle lib/hola/*.so
+RUBYOPT="--disable-gems -I$RG/lib -rrubygems" $RUBY -S rake native gem 2>&1 | grep -E "Content-addressed"
+GEM=$(ls pkg/hola-1.0.0-*.gem)
+cp "$GEM" "$WORK/srv/gems/"
+echo "   gem: $(basename "$GEM")"
+
+echo "== render v1 compact-index files (source + fat + skinny) =="
+RUBYOPT="--disable-gems -I$RG/lib -rrubygems" $RUBY - "$GEM" "$WORK/srv" "$CA_SUPPORTED_FROM" <<'RUBY'
+require "rubygems/package"
+require "digest"
+gemfile, srv, gate = ARGV
+spec   = Gem::Package.new(gemfile).spec
+sha256 = Digest::SHA256.hexdigest(File.binread(gemfile))
+addr   = sha256[0, 10]                                  # content address == sha in the filename
+real   = spec.platform.to_s                             # e.g. arm64-darwin-24
+ruby   = spec.required_ruby_version.as_list.join("&")   # e.g. "~> 4.0.0"
+
+# Three rows for hola 1.0.0, content-addressable rows last (per the proposal):
+#   source : version slot has no platform
+#   fat     : version slot = real platform (broad ruby req)
+#   skinny  : version slot = <sha>, real platform in platform: token, rubygems: gate
+info  = +"---\n"
+info << "1.0.0 |checksum:#{"a" * 64},ruby:>= 2.7,rubygems:>= 3.3.22\n"
+info << "1.0.0-#{real} |checksum:#{"b" * 64},ruby:>= 2.7\n"
+info << "1.0.0-#{addr} |checksum:#{sha256},ruby:#{ruby},rubygems:>= #{gate},platform:= #{real}\n"
+File.write(File.join(srv, "info/hola"), info)
+
+versions = +"created_at: 2024-01-01T00:00:00Z\n---\n"
+versions << "hola 1.0.0,1.0.0-#{real},1.0.0-#{addr} #{Digest::MD5.hexdigest(info)}\n"
+File.write(File.join(srv, "versions"), versions)
+
+warn "   filename sha == sha256[0,10]? #{File.basename(gemfile).include?(addr)}"
+info.lines.drop(1).each {|l| warn "   /info/hola: #{l.chomp}" }
+RUBY
+
+# IMPORTANT: bundle must load the PATCHED rubygems core (content-addressable
+# Gem::Platform), not Ruby's built-in rubygems, or the <sha> platform token
+# normalizes to "unknown".
+export RUBYOPT="--disable-gems -I$RG/lib -rrubygems"
+
+echo "== start fake v1 compact-index server =="
+$RUBY "$HERE/fake_compact_index.rb" "$WORK/srv" "$PORT" 2>"$WORK/srv.log" &
+SRV=$!
+trap 'kill $SRV 2>/dev/null || true' EXIT
+sleep 1
+
+echo "== bundle install (REMOTE, v1 index, from fake server) =="
+cd "$WORK/app"
+printf 'source "http://127.0.0.1:%s"\ngem "hola"\n' "$PORT" > Gemfile
+$BUNDLE install 2>&1 | grep -iE "fetching|installing|complete|could not|error" || true
+echo "   installed: $(basename "$(ls -d "$GEM_HOME"/gems/hola-* 2>/dev/null)")"
+
+echo "== prove the SKINNY gem was the one downloaded =="
+if grep -q "GET /gems/hola-1.0.0-${GEM##*hola-1.0.0-}" "$WORK/srv.log" 2>/dev/null; then :; fi
+grep "GET /gems/" "$WORK/srv.log" | sed 's/^/   /'
+
+echo "== bundle exec require =="
+$BUNDLE exec ruby -e 'require "hola"; puts "   => " + hola'
+
+echo
+echo "== server request log =="
+sed 's/^/   /' "$WORK/srv.log"
+echo "ALL GOOD"

--- a/dev/content-addressable-v1-demo/test_remote_v1_oldclient.sh
+++ b/dev/content-addressable-v1-demo/test_remote_v1_oldclient.sh
@@ -1,0 +1,146 @@
+#!/usr/bin/env bash
+#
+# Backwards-compatibility test: an OLD client (stock RubyGems/Bundler, WITHOUT
+# the content-addressable patches and with a RubyGems version older than the
+# `rubygems:>= 4.1.0.dev` gate) must transparently ignore the skinny rows in a
+# v1 compact index and install the ordinary fat binary instead.
+#
+# The publisher/registry is "new" (gems built with the patched RubyGems), but
+# the consumer is "old". This is the exact upgrade ordering the proposal relies
+# on (ship the consuming side first, then publish content-addressable gems).
+#
+# Proves:
+#   - the old client never requests /gems/hola-1.0.0-<sha>.gem (the skinny gem)
+#   - it installs the fat hola-1.0.0-<platform>.gem and `require` works
+#   - no crash/parse error on the skinny row's <sha> version token or its
+#     `platform:` metadata token
+#
+# Then re-runs with the NEW (patched) client to show it DOES pick the skinny one.
+set -euo pipefail
+
+CA_SUPPORTED_FROM="4.1.0.dev"
+HERE="$(cd "$(dirname "$0")" && pwd)"
+RG="$(cd "$HERE/../.." && pwd)"
+DEMO="$HERE/demo"
+WORK=/tmp/ca-v1-oldclient
+PORT="${PORT:-8899}"
+
+if [ -n "${RUBY_PREFIX:-}" ]; then export PATH="$RUBY_PREFIX/bin:$PATH"; fi
+RUBY="$(command -v ruby)"
+
+rm -rf "$WORK"; mkdir -p "$WORK/srv/gems" "$WORK/srv/info" "$WORK/app-old" "$WORK/app-new"
+# Clean GEM_HOME/GEM_PATH so the stock client doesn't load ABI-mismatched native
+# gems from ~/.gem (which would crash, unrelated to this feature).
+export GEM_HOME="$WORK/buildhome" GEM_PATH="$WORK/buildhome"
+echo "ruby: $($RUBY -e 'print RUBY_VERSION, " ", RUBY_PLATFORM')"
+echo "stock client: RubyGems $($RUBY -e 'puts Gem::VERSION'), Bundler $($RUBY -e 'require "bundler"; puts Bundler::VERSION')"
+
+echo
+echo "== install released rake-compiler =="
+$RUBY -S gem install rake-compiler --no-document >/dev/null
+
+SRC="$WORK/build"
+rm -rf "$SRC"; cp -R "$DEMO" "$SRC"; rm -rf "$SRC/tmp" "$SRC/pkg" "$SRC"/lib/hola/*.bundle "$SRC"/lib/hola/*.so
+MINOR="$($RUBY -e 'print RUBY_VERSION.split(".").first(2).join(".")')"
+PLATFORM="$($RUBY -e 'print Gem::Platform.local.to_s')"
+
+echo "== build SKINNY binary: rake native gem =="
+echo "   (rake-compiler pins required_ruby_version to a single ABI -> content-addressable)"
+( cd "$SRC" && RUBYOPT="--disable-gems -I$RG/lib -rrubygems" $RUBY -S rake native gem 2>&1 | grep -E "Content-addressed" )
+SKINNY="$(ls "$SRC"/pkg/hola-1.0.0-*.gem)"
+echo "   $(basename "$SKINNY")"
+
+echo "== build FAT binary: repackage the compiled .bundle with ruby >= 2.7 =="
+echo "   (spans many ABIs -> NOT content-addressable, keeps name-version-platform)"
+# Reuse the just-compiled native lib so `require` works on this Ruby, but give it
+# a broad required_ruby_version and an explicit platform so it is a plain fat
+# binary, bypassing rake-compiler's single-ABI pinning.
+cat > "$SRC/fat.gemspec" <<GEMSPEC
+Gem::Specification.new do |s|
+  s.name        = "hola"
+  s.version     = "1.0.0"
+  s.summary     = "content-addressable native gem demo (fat)"
+  s.authors     = ["poc"]
+  s.platform    = "$PLATFORM"
+  s.files       = Dir["lib/**/*.rb"] + Dir["lib/**/*.bundle"] + Dir["lib/**/*.so"]
+  s.required_ruby_version = ">= 2.7"
+end
+GEMSPEC
+( cd "$SRC" && RUBYOPT="--disable-gems -I$RG/lib -rrubygems" $RUBY -S gem build fat.gemspec 2>&1 | grep -iE "file:|warning" || true )
+FAT="$(ls "$SRC"/hola-1.0.0-*.gem | grep -v -- "-pkg" | head -1)"
+echo "   $(basename "$FAT")"
+
+cp "$FAT" "$SKINNY" "$WORK/srv/gems/"
+
+echo "== render v1 /info/hola (fat ungated + skinny gated) =="
+RUBYOPT="--disable-gems -I$RG/lib -rrubygems" $RUBY - "$FAT" "$SKINNY" "$WORK/srv" "$CA_SUPPORTED_FROM" <<'RUBY'
+require "rubygems/package"
+require "digest"
+fat, skinny, srv, gate = ARGV
+fspec = Gem::Package.new(fat).spec
+fsha  = Digest::SHA256.hexdigest(File.binread(fat))
+ssha  = Digest::SHA256.hexdigest(File.binread(skinny))
+addr  = ssha[0, 10]
+real  = fspec.platform.to_s
+sruby = Gem::Package.new(skinny).spec.required_ruby_version.as_list.join("&")
+
+info  = +"---\n"
+info << "1.0.0-#{real} |checksum:#{fsha},ruby:>= 2.7\n"
+info << "1.0.0-#{addr} |checksum:#{ssha},ruby:#{sruby},rubygems:>= #{gate},platform:= #{real}\n"
+File.write(File.join(srv, "info/hola"), info)
+
+versions = +"created_at: 2024-01-01T00:00:00Z\n---\n"
+versions << "hola 1.0.0-#{real},1.0.0-#{addr} #{Digest::MD5.hexdigest(info)}\n"
+File.write(File.join(srv, "versions"), versions)
+
+File.write(File.join(srv, "addr.txt"), addr)   # so the shell knows the skinny filename
+info.lines.drop(1).each {|l| warn "   /info/hola: #{l.chomp}" }
+RUBY
+ADDR="$(cat "$WORK/srv/addr.txt")"
+
+echo
+echo "== start fake v1 compact-index server =="
+$RUBY "$HERE/fake_compact_index.rb" "$WORK/srv" "$PORT" 2>"$WORK/srv.log" &
+SRV=$!
+trap 'kill $SRV 2>/dev/null || true' EXIT
+sleep 1
+
+# ---------------------------------------------------------------------------
+# OLD CLIENT: stock RubyGems + Bundler, no patches. Must ignore the skinny row.
+# ---------------------------------------------------------------------------
+echo
+echo "########## OLD CLIENT (stock RubyGems $($RUBY -e 'puts Gem::VERSION')) ##########"
+cd "$WORK/app-old"
+export GEM_HOME="$WORK/old-gemhome" GEM_PATH="$WORK/old-gemhome"
+unset RUBYOPT   # <-- do NOT load the patched rubygems/bundler
+printf 'source "http://127.0.0.1:%s"\ngem "hola"\n' "$PORT" > Gemfile
+$RUBY -S bundle install 2>&1 | grep -iE "fetching|installing|complete|could not|error" || true
+echo "   installed: $(basename "$(ls -d "$GEM_HOME"/gems/hola-* 2>/dev/null)")"
+$RUBY -S bundle exec ruby -e 'require "hola"; puts "   => " + hola'
+
+if grep -q "GET /gems/hola-1.0.0-${ADDR}.gem" "$WORK/srv.log"; then
+  echo "FAIL: old client requested the SKINNY gem (hola-1.0.0-${ADDR}.gem)"; exit 1
+fi
+echo "   [check] old client never requested the skinny gem (hola-1.0.0-${ADDR}.gem) -> OK"
+
+# ---------------------------------------------------------------------------
+# NEW CLIENT: patched RubyGems + Bundler. Must pick the skinny row.
+# ---------------------------------------------------------------------------
+echo
+echo "########## NEW CLIENT (patched RubyGems 4.1.0.dev) ##########"
+cd "$WORK/app-new"
+export GEM_HOME="$WORK/new-gemhome" GEM_PATH="$WORK/new-gemhome"
+export RUBYOPT="--disable-gems -I$RG/lib -rrubygems"
+printf 'source "http://127.0.0.1:%s"\ngem "hola"\n' "$PORT" > Gemfile
+$RUBY -I"$RG/bundler/lib" "$RG/bundler/exe/bundle" install 2>&1 | grep -iE "fetching|installing|complete|could not|error" || true
+$RUBY -I"$RG/bundler/lib" "$RG/bundler/exe/bundle" exec ruby -e 'require "hola"; puts "   => " + hola'
+if grep -q "GET /gems/hola-1.0.0-${ADDR}.gem" "$WORK/srv.log"; then
+  echo "   [check] new client requested the skinny gem (hola-1.0.0-${ADDR}.gem) -> OK"
+else
+  echo "FAIL: new client did NOT request the skinny gem"; exit 1
+fi
+
+echo
+echo "== server request log (/gems only) =="
+grep "GET /gems/" "$WORK/srv.log" | sed 's/^/   /'
+echo "ALL GOOD"

--- a/dev/content-addressable-v1-demo/test_resolution.sh
+++ b/dev/content-addressable-v1-demo/test_resolution.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# Prove that content-addressable ("skinny") gems encoded in the v1 compact
+# index are chosen over fat + source variants by a new client, and ignored by
+# old clients via the `rubygems:` gate.
+#
+# Loads the patched RubyGems + Bundler from this checkout (no install needed).
+set -euo pipefail
+
+# Locate the rubygems checkout (two levels up from this script).
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO="$(cd "$HERE/../.." && pwd)"
+
+echo "Using rubygems checkout: $REPO"
+exec ruby --disable-gems -I"$REPO/lib" -rrubygems -I"$REPO/bundler/lib" \
+  "$HERE/prove_resolution.rb"

--- a/lib/rubygems/basic_specification.rb
+++ b/lib/rubygems/basic_specification.rb
@@ -30,6 +30,14 @@ class Gem::BasicSpecification
 
   attr_writer :full_gem_path # :nodoc:
 
+  ##
+  # The version suffix (first 10 hex of the gem's sha256) for a content-
+  # addressable ("skinny") binary. When set, it replaces the platform in
+  # +full_name+, so the gem downloads/installs/stubs under name-version-<sha>.
+  # nil for ordinary gems.
+
+  attr_accessor :version_suffix # :nodoc:
+
   def initialize
     internal_init
   end
@@ -145,7 +153,9 @@ class Gem::BasicSpecification
   # default Ruby platform.
 
   def full_name
-    if platform == Gem::Platform::RUBY || platform.nil?
+    if version_suffix
+      "#{name}-#{version}-#{version_suffix}"
+    elsif platform == Gem::Platform::RUBY || platform.nil?
       "#{name}-#{version}"
     else
       "#{name}-#{version}-#{platform}"

--- a/lib/rubygems/installer.rb
+++ b/lib/rubygems/installer.rb
@@ -255,6 +255,22 @@ class Gem::Installer
   end
 
   ##
+  # Derive the version suffix (sha256[0,10]) from the gem's bytes for a
+  # content-addressable ("skinny") binary, so full_name -> name-version-<sha>
+  # and the stub records the sha. Computed from content, so the builder, the
+  # installer, and a registry all derive the same value without coordination.
+
+  def assign_version_suffix
+    return unless spec.content_addressable?
+    return unless @package.gem.respond_to?(:path)
+
+    require "digest"
+    spec.version_suffix = Digest::SHA256.file(@package.gem.path).hexdigest[0, 10]
+  rescue StandardError
+    nil
+  end
+
+  ##
   # Installs the gem and returns a loaded Gem::Specification for the installed
   # gem.
   #
@@ -266,6 +282,11 @@ class Gem::Installer
   #     specifications/<gem-version>.gemspec #=> the Gem::Specification
 
   def install
+    # For a content-addressable ("skinny") binary, derive the version suffix
+    # from the gem's bytes so full_name -> gems/name-version-<sha>/ and the stub
+    # records the sha. Must run before any path (gem_dir/spec_file) is computed.
+    assign_version_suffix
+
     pre_install_checks
 
     run_pre_install_hooks

--- a/lib/rubygems/installer.rb
+++ b/lib/rubygems/installer.rb
@@ -255,20 +255,145 @@ class Gem::Installer
   end
 
   ##
-  # Derive the version suffix (sha256[0,10]) from the gem's bytes for a
+  # Derive the version suffix (a hex prefix of sha256(.gem)) for a
   # content-addressable ("skinny") binary, so full_name -> name-version-<sha>
-  # and the stub records the sha. Computed from content, so the builder, the
-  # installer, and a registry all derive the same value without coordination.
+  # and the stub records the sha.
+  #
+  # The width is *authoritative when it comes from the file name* (e.g.
+  # name-version-<sha>.gem as published by the registry / `gem build`). We use
+  # that width verbatim and only sanity-check that it is a prefix of the real
+  # digest. Recomputing the width locally would diverge from the index token,
+  # the download URL, and the lockfile, so the registry owns collision
+  # resolution and the client just trusts the token it was given.
+  #
+  # Only a bare local install whose file name carries no token falls back to
+  # the default width, growing it just enough to avoid clobbering a *different*
+  # gem already installed under the same name, version, and prefix.
 
   def assign_version_suffix
     return unless spec.content_addressable?
     return unless @package.gem.respond_to?(:path)
 
     require "digest"
-    spec.version_suffix = Digest::SHA256.file(@package.gem.path).hexdigest[0, 10]
+    full_digest = Digest::SHA256.file(@package.gem.path).hexdigest
+
+    spec.version_suffix =
+      version_suffix_from_filename(full_digest) ||
+      unique_local_version_suffix(full_digest)
+
+    # Converge byte-identical installs onto a single canonical directory and
+    # remove any other-width duplicates. Best-effort: never let this unset the
+    # suffix already assigned above.
+    converge_content_address(full_digest)
   rescue StandardError
     nil
   end
+
+  ##
+  # Ensure exactly one directory holds this content. The registry only widens a
+  # content address past the default on collision, so a *wider* suffix is the
+  # authoritative remote address: we prefer it over a narrower local build, and
+  # prune any byte-identical install at a different width (leaving two would
+  # make activation order nondeterministic, since they share name+version+
+  # platform and differ only in the suffix).
+
+  def converge_content_address(full_digest)
+    canonical = ([spec.version_suffix] + same_content_version_suffixes(full_digest)).compact.max_by(&:length)
+    return unless canonical
+
+    spec.version_suffix = canonical
+
+    same_content_version_suffixes(full_digest).each do |token|
+      next if token == canonical
+      remove_content_address_install("#{spec.name}-#{spec.version}-#{token}")
+    end
+  rescue StandardError
+    nil
+  end
+  private :converge_content_address
+
+  ##
+  # Trust a version suffix carried by the gem's file name (the registry/build
+  # token). Returns it only when it is well-formed and an actual prefix of the
+  # gem's real digest; otherwise nil so the caller derives one locally.
+
+  def version_suffix_from_filename(full_digest)
+    base = File.basename(@package.gem.path.to_s, ".gem")
+    token = base.split("-").last
+    return unless Gem::Platform.version_suffix?(token)
+    return unless full_digest.start_with?(token)
+
+    token
+  end
+  private :version_suffix_from_filename
+
+  ##
+  # Choose the version suffix for a bare local install (no token in the file
+  # name). The width is content-canonical:
+  #
+  # * If the *same content* is already installed under some width (matched by
+  #   full digest, never by truncated prefix — a prefix is ambiguous when two
+  #   distinct gems collided), reuse the widest such width so identical bytes
+  #   never materialize twice under different names.
+  # * Otherwise use the default width, growing it only to avoid clobbering a
+  #   *different* gem that already occupies the same prefix.
+
+  def unique_local_version_suffix(full_digest)
+    reuse = same_content_version_suffixes(full_digest).max_by(&:length)
+    return reuse if reuse
+
+    length = Gem::Platform::DEFAULT_VERSION_SUFFIX_LENGTH
+
+    while length < full_digest.length
+      candidate = full_digest[0, length]
+      dir = File.join(gem_home, "gems", "#{spec.name}-#{spec.version}-#{candidate}")
+      break unless File.directory?(dir)
+
+      # A different gem occupies this prefix (same content was handled above):
+      # widen to avoid clobbering it.
+      length += 2
+    end
+
+    full_digest[0, length]
+  end
+  private :unique_local_version_suffix
+
+  ##
+  # Version suffixes of already-installed directories whose gem has identical
+  # content (full sha256 == +full_digest+) under this name and version.
+  # Matching is by full digest, which is unambiguous; a shared prefix is not,
+  # since two colliding gems share the default-width prefix by definition.
+
+  def same_content_version_suffixes(full_digest)
+    gems = File.join(gem_home, "gems")
+    return [] unless File.directory?(gems)
+
+    prefix = "#{spec.name}-#{spec.version}-"
+    Dir.children(gems).filter_map do |entry|
+      next unless entry.start_with?(prefix)
+
+      token = entry[prefix.length..]
+      next unless Gem::Platform.version_suffix?(token)
+      next unless full_digest.start_with?(token)
+
+      cached = File.join(gem_home, "cache", "#{entry}.gem")
+      token if File.file?(cached) && Digest::SHA256.file(cached).hexdigest == full_digest
+    end
+  end
+  private :same_content_version_suffixes
+
+  ##
+  # Remove a content-addressed install (gem dir, cached gem, gemspec stub, and
+  # built extensions) by its full_name. Used to prune a byte-identical
+  # duplicate that lives at a different content-address width.
+
+  def remove_content_address_install(full_name)
+    FileUtils.rm_rf File.join(gem_home, "gems", full_name)
+    FileUtils.rm_f  File.join(gem_home, "cache", "#{full_name}.gem")
+    FileUtils.rm_f  File.join(gem_home, "specifications", "#{full_name}.gemspec")
+    Dir.glob(File.join(gem_home, "extensions", "*", "*", full_name)).each {|d| FileUtils.rm_rf d }
+  end
+  private :remove_content_address_install
 
   ##
   # Installs the gem and returns a loaded Gem::Specification for the installed

--- a/lib/rubygems/package.rb
+++ b/lib/rubygems/package.rb
@@ -130,6 +130,30 @@ class Gem::Package
   attr_accessor :data_mode
 
   def self.build(spec, skip_validation = false, strict_validation = false, file_name = nil)
+    # Content-address skinny binaries (platformed + single Ruby ABI) so multiple
+    # per-Ruby builds of the same version+platform can coexist. The file name
+    # embeds sha256(.gem)[0, 10], which isn't known until the gem is built, so
+    # build it in memory: this lets us compute the checksum from the bytes and
+    # write the content-addressed file in a single pass, instead of writing the
+    # gem to disk, reading it back to hash it, and renaming. Skipped when an
+    # explicit output file name was requested.
+    if file_name.nil? && spec.content_addressable?
+      require "digest"
+      require "stringio"
+
+      buffer = StringIO.new(+"".b)
+      package = new buffer
+      package.spec = spec
+      package.build skip_validation, strict_validation
+
+      data = buffer.string
+      sha = Digest::SHA256.hexdigest(data)[0, 10]
+      gem_file = "#{spec.name}-#{spec.version}-#{sha}.gem"
+      File.binwrite(gem_file, data)
+      package.say "  Content-addressed: #{gem_file}"
+      return gem_file
+    end
+
     gem_file = file_name || spec.file_name
 
     package = new gem_file
@@ -319,7 +343,7 @@ class Gem::Package
   Successfully built RubyGem
   Name: #{@spec.name}
   Version: #{@spec.version}
-  File: #{File.basename @gem.path}
+  File: #{@gem.path ? File.basename(@gem.path) : @spec.file_name}
 EOM
   ensure
     @signer = nil

--- a/lib/rubygems/package.rb
+++ b/lib/rubygems/package.rb
@@ -132,7 +132,8 @@ class Gem::Package
   def self.build(spec, skip_validation = false, strict_validation = false, file_name = nil)
     # Content-address skinny binaries (platformed + single Ruby ABI) so multiple
     # per-Ruby builds of the same version+platform can coexist. The file name
-    # embeds sha256(.gem)[0, 10], which isn't known until the gem is built, so
+    # embeds sha256(.gem)[0, DEFAULT_VERSION_SUFFIX_LENGTH], which isn't known
+    # until the gem is built, so
     # build it in memory: this lets us compute the checksum from the bytes and
     # write the content-addressed file in a single pass, instead of writing the
     # gem to disk, reading it back to hash it, and renaming. Skipped when an
@@ -147,7 +148,7 @@ class Gem::Package
       package.build skip_validation, strict_validation
 
       data = buffer.string
-      sha = Digest::SHA256.hexdigest(data)[0, 10]
+      sha = Digest::SHA256.hexdigest(data)[0, Gem::Platform::DEFAULT_VERSION_SUFFIX_LENGTH]
       gem_file = "#{spec.name}-#{spec.version}-#{sha}.gem"
       File.binwrite(gem_file, data)
       package.say "  Content-addressed: #{gem_file}"

--- a/lib/rubygems/package_task.rb
+++ b/lib/rubygems/package_task.rb
@@ -111,10 +111,12 @@ class Gem::PackageTask < Rake::PackageTask
     file gem_path => [package_dir, gem_dir] + @gem_spec.files do
       chdir(gem_dir) do
         when_writing "Creating #{gem_spec.file_name}" do
-          Gem::Package.build gem_spec
+          # build may content-address the file (skinny binaries), so move the
+          # name it actually produced rather than the assumed platform name.
+          built_file = File.basename(Gem::Package.build(gem_spec))
 
           verbose trace do
-            mv gem_file, ".."
+            mv built_file, ".."
           end
         end
       end

--- a/lib/rubygems/platform.rb
+++ b/lib/rubygems/platform.rb
@@ -11,17 +11,25 @@ class Gem::Platform
   attr_accessor :cpu, :os, :version
 
   # For content-addressable ("skinny") binaries, the "platform" token is a
-  # 10-char hex prefix of the gem's SHA256 rather than a real cpu/os/version.
-  # It is kept in its own field so it never masquerades as an operating system.
+  # hex prefix of the gem's SHA256 rather than a real cpu/os/version. It is
+  # kept in its own field so it never masquerades as an operating system.
   attr_reader :version_suffix
 
   ##
-  # A version suffix is a 10-char hex prefix of a gem's SHA256 checksum, used
-  # by content-addressable ("skinny") binaries in the version token's platform
+  # A version suffix is a hex prefix of a gem's SHA256 checksum, used by
+  # content-addressable ("skinny") binaries in the version token's platform
   # slot. The real platform lives in the compact index `platform:` requirement
   # instead of in the version token.
+  #
+  # The default width is DEFAULT_VERSION_SUFFIX_LENGTH; it may be widened (up
+  # to the full 64-char digest) to disambiguate two distinct gems that share
+  # the same name, version, and default-width prefix. The width is carried by
+  # the authoritative token (the registry/build file name), never recomputed,
+  # so a wider token flows through full_name, paths, and download URLs as-is.
 
-  VERSION_SUFFIX = /\A[0-9a-f]{10}\z/
+  DEFAULT_VERSION_SUFFIX_LENGTH = 8
+
+  VERSION_SUFFIX = /\A[0-9a-f]{#{DEFAULT_VERSION_SUFFIX_LENGTH},64}\z/
 
   def self.version_suffix?(string)
     string.is_a?(String) && VERSION_SUFFIX.match?(string)

--- a/lib/rubygems/platform.rb
+++ b/lib/rubygems/platform.rb
@@ -10,6 +10,27 @@ class Gem::Platform
 
   attr_accessor :cpu, :os, :version
 
+  # For content-addressable ("skinny") binaries, the "platform" token is a
+  # 10-char hex prefix of the gem's SHA256 rather than a real cpu/os/version.
+  # It is kept in its own field so it never masquerades as an operating system.
+  attr_reader :version_suffix
+
+  ##
+  # A version suffix is a 10-char hex prefix of a gem's SHA256 checksum, used
+  # by content-addressable ("skinny") binaries in the version token's platform
+  # slot. The real platform lives in the compact index `platform:` requirement
+  # instead of in the version token.
+
+  VERSION_SUFFIX = /\A[0-9a-f]{10}\z/
+
+  def self.version_suffix?(string)
+    string.is_a?(String) && VERSION_SUFFIX.match?(string)
+  end
+
+  def version_suffix?
+    !@version_suffix.nil?
+  end
+
   def self.local(refresh: false)
     return @local if @local && !refresh
     @local = begin
@@ -73,10 +94,27 @@ class Gem::Platform
   end
 
   def initialize(arch)
+    @version_suffix = nil
+
     case arch
     when Array then
-      @cpu, @os, @version = arch
+      cpu, os, version = arch
+      # Round-trip a version suffix that was serialized via #to_a.
+      if cpu.nil? && version.nil? && Gem::Platform.version_suffix?(os)
+        @version_suffix = os
+      else
+        @cpu, @os, @version = cpu, os, version
+      end
     when String then
+      # Preserve version-suffix SHA prefixes verbatim (e.g. "ef716ba7a6").
+      # They have no cpu/os/version; otherwise they would normalize to
+      # os="unknown", destroying the hash used in filenames, lockfile
+      # entries, and download URLs.
+      if Gem::Platform.version_suffix?(arch)
+        @version_suffix = arch
+        return
+      end
+
       cpu, os = arch.sub(/-+$/, "").split("-", 2)
 
       @cpu = if cpu&.match?(/i\d86/)
@@ -122,17 +160,20 @@ class Gem::Platform
       @cpu = arch.cpu
       @os = arch.os
       @version = arch.version
+      @version_suffix = arch.version_suffix
     else
       raise ArgumentError, "invalid argument #{arch.inspect}"
     end
   end
 
   def to_a
+    return [nil, @version_suffix, nil] if version_suffix?
     [@cpu, @os, @version]
   end
 
   def to_s
-    to_a.compact.join(@cpu.nil? ? "" : "-")
+    return @version_suffix if version_suffix?
+    [@cpu, @os, @version].compact.join(@cpu.nil? ? "" : "-")
   end
 
   ##
@@ -171,13 +212,13 @@ class Gem::Platform
   # the same CPU, OS and version.
 
   def ==(other)
-    self.class === other && to_a == other.to_a
+    self.class === other && version_suffix == other.version_suffix && to_a == other.to_a
   end
 
   alias_method :eql?, :==
 
   def hash # :nodoc:
-    to_a.hash
+    [@version_suffix, @cpu, @os, @version].hash
   end
 
   ##
@@ -200,6 +241,12 @@ class Gem::Platform
 
   def ===(other)
     return nil unless Gem::Platform === other
+
+    # A version suffix only matches the identical version suffix; it never
+    # fuzzy-matches a real platform (and vice versa).
+    if version_suffix? || other.version_suffix?
+      return version_suffix == other.version_suffix
+    end
 
     # universal-mingw32 matches x64-mingw-ucrt
     return true if (@cpu == "universal" || other.cpu == "universal") &&

--- a/lib/rubygems/specification.rb
+++ b/lib/rubygems/specification.rb
@@ -557,6 +557,52 @@ class Gem::Specification < Gem::BasicSpecification
   end
 
   ##
+  # True for a "skinny" precompiled binary: a platformed gem pinned to a single
+  # Ruby ABI. These are content-addressed (name-version-<sha>) at build time so
+  # multiple per-Ruby builds of the same version+platform can coexist. Fat
+  # binaries (spanning many Ruby ABIs) and source gems are not.
+
+  def content_addressable?
+    return false if platform.nil? || platform == Gem::Platform::RUBY
+
+    !content_addressable_ruby_abi.nil?
+  end
+
+  ##
+  # The single "MAJOR.MINOR" Ruby series this gem targets, or nil if it spans
+  # more than one. Recognizes both `~> X.Y.Z` and the `>= X.Y, < X.(Y+1).dev`
+  # range rake-compiler emits for single-ABI native gems.
+
+  def content_addressable_ruby_abi
+    reqs = required_ruby_version.requirements
+    return nil if reqs.empty?
+
+    if reqs.size == 1
+      operator, version = reqs.first
+      return nil unless operator == "~>"
+      segments = version.segments
+      return nil unless segments.size >= 3
+
+      return segments.first(2).join(".")
+    end
+
+    if reqs.size == 2
+      lower = reqs.find {|op, _| [">=", ">"].include?(op) }
+      upper = reqs.find {|op, _| ["<", "<="].include?(op) }
+      return nil unless lower && upper
+
+      lo = lower.last.segments
+      hi = upper.last.segments
+      return nil unless lo.size >= 2 && hi.size >= 2
+      return nil unless hi[0] == lo[0] && hi[1] == lo[1] + 1
+
+      return lo.first(2).join(".")
+    end
+
+    nil
+  end
+
+  ##
   # Executables included in the gem.
   #
   # For example, the rake gem has rake as an executable. You don't specify the
@@ -2370,7 +2416,10 @@ class Gem::Specification < Gem::BasicSpecification
   def to_ruby
     result = []
     result << "# -*- encoding: utf-8 -*-"
-    result << "#{Gem::StubSpecification::PREFIX}#{name} #{version} #{platform} #{raw_require_paths.join("\0")}"
+    stub = "#{Gem::StubSpecification::PREFIX}#{name} #{version} #{platform} #{raw_require_paths.join("\0")}"
+    # content-addressable binaries carry the sha so the stub can rebuild full_name
+    stub += " #{version_suffix}" if version_suffix
+    result << stub
     result << "#{Gem::StubSpecification::PREFIX}#{extensions.join "\0"}" unless
       extensions.empty?
     result << nil

--- a/lib/rubygems/stub_specification.rb
+++ b/lib/rubygems/stub_specification.rb
@@ -14,7 +14,7 @@ class Gem::StubSpecification < Gem::BasicSpecification
 
   class StubLine # :nodoc: all
     attr_reader :name, :version, :platform, :require_paths, :extensions,
-                :full_name
+                :full_name, :version_suffix
 
     NO_EXTENSIONS = [].freeze
 
@@ -34,7 +34,10 @@ class Gem::StubSpecification < Gem::BasicSpecification
     }.freeze
 
     def initialize(data, extensions)
-      parts          = data[PREFIX.length..-1].split(" ", 4)
+      # Fields: name version platform require_paths [version_suffix]
+      # The trailing version_suffix is present only for content-addressable
+      # ("skinny") binaries; old stubs have 4 fields and parse it as nil.
+      parts          = data[PREFIX.length..-1].split(" ", 5)
       @name          = -parts[0]
       @version       = if Gem::Version.correct?(parts[1])
         Gem::Version.new(parts[1])
@@ -42,15 +45,18 @@ class Gem::StubSpecification < Gem::BasicSpecification
         Gem::Version.new(0)
       end
 
-      @platform      = Gem::Platform.new parts[2]
-      @extensions    = extensions
-      @full_name     = if platform == Gem::Platform::RUBY
+      @platform        = Gem::Platform.new parts[2]
+      @extensions      = extensions
+      @version_suffix  = parts[4]
+      @full_name       = if @version_suffix
+        "#{name}-#{version}-#{@version_suffix}"
+      elsif platform == Gem::Platform::RUBY
         "#{name}-#{version}"
       else
         "#{name}-#{version}-#{platform}"
       end
 
-      path_list = parts.last
+      path_list = parts[3]
       @require_paths = REQUIRE_PATH_LIST[path_list] || path_list.split("\0").map! do |x|
         REQUIRE_PATHS[x] || x
       end
@@ -180,12 +186,24 @@ class Gem::StubSpecification < Gem::BasicSpecification
     data.full_name
   end
 
+  def version_suffix
+    data.version_suffix
+  end
+
   ##
   # The full Gem::Specification for this gem, loaded from evalling its gemspec
 
   def spec
     @spec ||= loaded_spec if @data
     @spec ||= Gem::Specification.load(loaded_from)
+    # The version suffix lives on the stub line, not in the gemspec body, so the
+    # freshly-evalled full spec wouldn't know its content-addressed full_name
+    # (and would compute name-version-platform paths that don't exist on disk).
+    # Carry it over from the stub.
+    if @spec && !@spec.version_suffix && (vs = version_suffix) && !vs.empty?
+      @spec.version_suffix = vs
+    end
+    @spec
   end
   alias_method :to_spec, :spec
 

--- a/test/rubygems/test_gem_installer_version_suffix.rb
+++ b/test/rubygems/test_gem_installer_version_suffix.rb
@@ -1,0 +1,187 @@
+# frozen_string_literal: true
+
+require_relative "helper"
+require "rubygems/installer"
+require "rubygems/package"
+require "digest"
+require "fileutils"
+
+##
+# Exercises how Gem::Installer assigns the content-addressable version suffix:
+# it trusts the width carried by the gem's file name (the registry/build token)
+# and only derives/grows a width locally for a bare local install whose file
+# name carries no token.
+
+class TestGemInstallerVersionSuffix < Gem::TestCase
+  def setup
+    super
+
+    abi = RUBY_VERSION.split(".").first(2).join(".")
+    @spec = Gem::Specification.new do |s|
+      s.name                 = "skinny"
+      s.version              = "1.0.0"
+      s.summary              = "skinny binary fixture"
+      s.authors              = ["Test"]
+      s.platform             = Gem::Platform.new("x86_64-linux")
+      s.required_ruby_version = "~> #{abi}.0"
+      s.files                = []
+    end
+
+    assert @spec.content_addressable?, "fixture must be content-addressable"
+  end
+
+  def build_gem
+    Dir.chdir @tempdir do
+      File.join(@tempdir, Gem::Package.build(@spec))
+    end
+  end
+
+  def install(path)
+    installer = Gem::Installer.at(path, force: true)
+    installer.install
+    installer
+  end
+
+  def gem_dir(suffix)
+    File.join @gemhome, "gems", "skinny-1.0.0-#{suffix}"
+  end
+
+  def test_default_width_taken_from_built_file_name
+    gem  = build_gem
+    full = Digest::SHA256.file(gem).hexdigest
+
+    installer = install(gem)
+
+    assert_equal full[0, 8], installer.spec.version_suffix
+    assert_path_exist gem_dir(full[0, 8])
+  end
+
+  def test_trusts_wider_registry_token_verbatim
+    gem  = build_gem
+    full = Digest::SHA256.file(gem).hexdigest
+
+    # Registry published a wider token (collision resolved upstream); the
+    # download arrives as name-version-<sha10>.gem. The client must use that
+    # width as-is rather than recomputing the default width.
+    wider = File.join(@tempdir, "skinny-1.0.0-#{full[0, 10]}.gem")
+    FileUtils.mv gem, wider
+
+    installer = install(wider)
+
+    assert_equal full[0, 10], installer.spec.version_suffix
+    assert_path_exist gem_dir(full[0, 10])
+  end
+
+  def test_ignores_filename_token_that_is_not_a_real_prefix
+    gem  = build_gem
+    full = Digest::SHA256.file(gem).hexdigest
+
+    # A token that looks valid but is not a prefix of the real digest must be
+    # rejected, falling back to a locally-derived width.
+    bogus = full[0, 8].tr("0123456789abcdef", "fedcba9876543210")
+    refute full.start_with?(bogus)
+    renamed = File.join(@tempdir, "skinny-1.0.0-#{bogus}.gem")
+    FileUtils.mv gem, renamed
+
+    installer = install(renamed)
+
+    assert_equal full[0, 8], installer.spec.version_suffix
+  end
+
+  def test_grows_width_on_local_collision
+    gem  = build_gem
+    full = Digest::SHA256.file(gem).hexdigest
+
+    # Bare local install: strip the token so the installer derives one locally.
+    plain = File.join(@tempdir, "skinny-1.0.0.gem")
+    FileUtils.cp gem, plain
+
+    # A *different* gem already occupies the default-width prefix.
+    FileUtils.mkdir_p gem_dir(full[0, 8])
+    FileUtils.mkdir_p File.join(@gemhome, "cache")
+    File.binwrite File.join(@gemhome, "cache", "skinny-1.0.0-#{full[0, 8]}.gem"),
+                  "a-different-gem"
+
+    installer = install(plain)
+
+    assert_equal full[0, 10], installer.spec.version_suffix
+    assert_path_exist gem_dir(full[0, 10])
+  end
+
+  def test_reuses_existing_wider_width_for_identical_content
+    gem  = build_gem
+    full = Digest::SHA256.file(gem).hexdigest
+
+    plain = File.join(@tempdir, "skinny-1.0.0.gem")
+    FileUtils.cp gem, plain
+
+    # The same content is already installed under a *wider* width (e.g. the
+    # registry grew it). A local install of identical bytes must reuse that
+    # directory, not create a second copy at the default width.
+    FileUtils.mkdir_p gem_dir(full[0, 10])
+    FileUtils.mkdir_p File.join(@gemhome, "cache")
+    FileUtils.cp gem, File.join(@gemhome, "cache", "skinny-1.0.0-#{full[0, 10]}.gem")
+
+    installer = install(plain)
+
+    assert_equal full[0, 10], installer.spec.version_suffix
+    assert_path_not_exist gem_dir(full[0, 8])
+  end
+
+  def test_reuses_width_on_idempotent_local_reinstall
+    gem  = build_gem
+    full = Digest::SHA256.file(gem).hexdigest
+
+    plain = File.join(@tempdir, "skinny-1.0.0.gem")
+    FileUtils.cp gem, plain
+
+    # The *same* content is already cached at the default width: keep that width.
+    FileUtils.mkdir_p gem_dir(full[0, 8])
+    FileUtils.mkdir_p File.join(@gemhome, "cache")
+    FileUtils.cp gem, File.join(@gemhome, "cache", "skinny-1.0.0-#{full[0, 8]}.gem")
+
+    installer = install(plain)
+
+    assert_equal full[0, 8], installer.spec.version_suffix
+  end
+
+  def test_installing_wider_registry_gem_prunes_stale_narrower_duplicate
+    gem  = build_gem
+    full = Digest::SHA256.file(gem).hexdigest
+
+    # A stale default-width (local) install of identical content is on disk.
+    FileUtils.mkdir_p gem_dir(full[0, 8])
+    FileUtils.mkdir_p File.join(@gemhome, "cache")
+    FileUtils.cp gem, File.join(@gemhome, "cache", "skinny-1.0.0-#{full[0, 8]}.gem")
+
+    # Now install the registry's wider (canonical) copy of the same bytes.
+    wider = File.join(@tempdir, "skinny-1.0.0-#{full[0, 10]}.gem")
+    FileUtils.cp gem, wider
+
+    installer = install(wider)
+
+    # The wider address wins, and the narrower duplicate is removed: exactly
+    # one directory remains, so activation is never a tie.
+    assert_equal full[0, 10], installer.spec.version_suffix
+    assert_path_exist gem_dir(full[0, 10])
+    assert_path_not_exist gem_dir(full[0, 8])
+  end
+
+  def test_installing_narrower_local_gem_adopts_existing_wider_remote
+    gem  = build_gem
+    full = Digest::SHA256.file(gem).hexdigest
+
+    # The wider (registry) copy is already installed.
+    FileUtils.mkdir_p gem_dir(full[0, 10])
+    FileUtils.mkdir_p File.join(@gemhome, "cache")
+    FileUtils.cp gem, File.join(@gemhome, "cache", "skinny-1.0.0-#{full[0, 10]}.gem")
+
+    # Installing a narrower local build of identical bytes must defer to the
+    # wider remote address rather than create a second directory.
+    installer = install(gem) # built file name carries the default width 8
+
+    assert_equal full[0, 10], installer.spec.version_suffix
+    assert_path_exist gem_dir(full[0, 10])
+    assert_path_not_exist gem_dir(full[0, 8])
+  end
+end


### PR DESCRIPTION
## Summary

Adds support for **content-addressable ("skinny") precompiled binaries** to
RubyGems and Bundler, encoded entirely in the **v1 compact index** — no `/v2/`
endpoint required.

A "skinny" binary is a platformed gem pinned to a single Ruby ABI (e.g.
`required_ruby_version = "~> 3.3.0"`, or rake-compiler's `>= 3.3, < 3.4.dev`).
Today every per-Ruby build of the same `name`–`version`–`platform` collides on
one identity, so a registry can host only one. This PR makes such gems **built,
named, installed, and resolved by content address** — `name-version-<sha>`,
where `<sha> = sha256(.gem)[0, 10]` — so multiple per-Ruby builds of the same
version+platform can coexist, and the correct one is selected at resolve time
based on the running Ruby.

Old clients keep working: skinny rows in the index carry a `rubygems:>=`
requirement, so a client older than the cutoff transparently ignores them and
installs the ordinary fat binary instead.

## Why v1 (and not a v2 endpoint)

This is the alternative to a separate `/v2/` compact-index namespace. Instead of
hiding content-addressable entries behind a new endpoint, we keep everything in
the existing v1 index and hide skinny rows from old clients with a `rubygems:>=`
gate. The per-gem info line carries the content address in the version token's
platform slot and the real platform in a `platform:` requirement token:

```
1.0.0                  |checksum:…,ruby:>= 3.1,rubygems:>= 3.3.22
1.0.0-x86_64-linux     |checksum:…,ruby:>= 3.1
1.0.0-9f3c1a2b…        |checksum:…,ruby:~> 3.3.0,rubygems:>= 4.1.0.dev,platform:= x86_64-linux
```

- The `<sha>` slot becomes the gem's `full_name` (and download path
  `/gems/name-version-<sha>.gem`).
- The `platform:` token carries the real platform, used for compatibility
  matching.
- `rubygems:>= 4.1.0.dev` gates the row: clients older than the version that
  ships this support don't satisfy it and drop the row during resolution. (The
  exact cutoff is a placeholder to be set to the release version; consuming
  support should ship before any registry starts publishing skinny gems.)

## Design

- **Identity:** `version_suffix = sha256(.gem)[0, 10]`, computed from bytes, so
  the builder, the installer, and a registry all derive the same value without
  coordination.
- **"Skinny" detection:** a gem is content-addressable when it is platformed and
  pinned to a single Ruby minor. Fat binaries (spanning many ABIs) and pure-Ruby
  gems are untouched.
- **Build:** `Gem::Package.build` builds a skinny gem **in memory**, computes the
  content address from the bytes, and writes `name-version-<sha>.gem` in a single
  pass — no write-then-read-then-rename. (A streaming digest can't be used here
  because `TarWriter` seeks backward to backfill headers, so the build IO must be
  seekable.)
- **Install:** installs under `gems/name-version-<sha>/`, with the 10-char sha
  recorded in the stub line so `full_name` reconstructs the content-addressed
  name offline (no `.gem` bytes required).
- **Lockfile:** stays portable. The lock records `name (version-platform)`;
  Bundler bridges that back to the on-disk `name-version-<sha>` at install time.
- **Resolution preference:** when a skinny binary compatible with the running
  Ruby exists, Bundler prefers it **exclusively**; otherwise it falls back to the
  fat/ruby variant so a usable binary is never stranded. Per-minor `~>` ranges
  are disjoint, so at most one skinny qualifies (no skinny-vs-skinny tie-break).

## Changes

### RubyGems core

- **`lib/rubygems/platform.rb`** — preserve a 10-hex-char `version_suffix` token
  verbatim instead of normalizing it to the bogus platform `"unknown"`;
  round-trips through `to_a`/`to_s`, and `==`/`hash`/`===` treat it as an
  exact-match token.
- **`lib/rubygems/specification.rb`** — `content_addressable?` /
  `content_addressable_ruby_abi` (skinny detection, both `~> X.Y.Z` and
  rake-compiler's `>= X.Y, < X.(Y+1).dev`); `to_ruby` writes the version suffix
  as an optional 5th stub-line field.
- **`lib/rubygems/package.rb`** — `Gem::Package.build` builds skinny gems in
  memory and writes `name-version-<sha>.gem` once; the build success message
  tolerates a `nil` path (so `IOSource` in-memory builds don't crash).
- **`lib/rubygems/package_task.rb`** — moves the (renamed) built file to the
  package dir.
- **`lib/rubygems/basic_specification.rb`** — `version_suffix` accessor;
  `full_name` returns `name-version-<sha>` when present.
- **`lib/rubygems/stub_specification.rb`** — reads the optional 5th stub-line
  field; `full_name` reconstructs the content-addressed name; `to_spec` carries
  the suffix onto the loaded full spec.
- **`lib/rubygems/installer.rb`** — `assign_version_suffix` derives the sha from
  the gem's bytes before any path is computed.

### Bundler

- **`endpoint_specification.rb`** — parses the compact-index `platform:` token
  into `platform_requirement`; `content_addressable?`; `installable_on_platform?`
  uses the real platform (since `@platform` holds the sha).
- **`match_platform.rb`** — `usable_skinny?` and the "prefer a Ruby-compatible
  skinny exclusively, else fall back to fat" selection.
- **`lazy_specification.rb`** — carries `platform_requirement`/`version_suffix`;
  content-addressed `full_name`; on a `--local` exact-match miss, retries by
  `name+version` so the portable lockfile entry resolves to the on-disk
  `name-version-<sha>` gem.
- **`stub_specification.rb`** — delegates `full_name`/`version_suffix` to the
  underlying RubyGems stub.

### Tests / tooling

- **`dev/content-addressable-v1-demo/`** — self-contained, dependency-free,
  native end-to-end tests (no containers, no rubygems.org): a tiny native demo
  gem, a fake v1 compact-index server, and scripts documented in a README.

## Testing

Verified natively on macOS (`arm64-darwin`); each script ends with `ALL GOOD`:

- **`test_resolution.sh`** — using the real parser + `EndpointSpecification` +
  `MatchPlatform`, a new client picks the skinny variant over source+fat, and an
  old client drops it via the `rubygems:>=` gate.
- **`test_local.sh`** — `rake native gem` builds the content-addressed gem;
  `gem install` lands it under `gems/name-version-<sha>/` with the sha in the
  stub; `bundle install --local` resolves it (lockfile round-trip), `require` +
  `bundle list` work, and re-install is idempotent.
- **`test_remote_v1.sh`** — against a fake v1 server, Bundler fetches
  `/versions` + `/info/<gem>` (no `/v2/`), selects the skinny variant, downloads
  `/gems/name-version-<sha>.gem`, installs, and `require` works.
- **`test_remote_v1_oldclient.sh`** — a stock RubyGems/Bundler older than the
  gate installs the fat binary and **never requests** the skinny gem, while the
  patched client picks the skinny one, against the same index.

```bash
cd dev/content-addressable-v1-demo
./test_resolution.sh
./test_local.sh
PORT=8920 ./test_remote_v1.sh
PORT=8920 ./test_remote_v1_oldclient.sh
```

## Relationship to #168

This is the v1-index alternative to #168 (which negotiates a `/v2/` compact-index
namespace). The build/install/resolution machinery is shared in spirit; the key
differences are **no v2 endpoint** (old clients are handled by the `rubygems:>=`
gate instead) and the naming (`version_suffix` / `platform_requirement` here vs
`content_address` / `real_platform` in #168).

## Known nuance

On the **remote** path the gem currently installs into
`gems/name-version-<real-platform>/`, whereas the **`--local`** path installs
into `gems/name-version-<sha>/`. Both are internally consistent and work for a
single active Ruby, but they disagree on the on-disk directory name.
