### PR TITLE
Support Content Addressable File Naming - Gem Build Flow

### DIFF
--- a/lib/rubygems/commands/build_command.rb
+++ b/lib/rubygems/commands/build_command.rb
@@ -25,6 +25,10 @@ class Gem::Commands::BuildCommand < Gem::Command
     add_option "-o", "--output FILE", "output gem with the given filename" do |value, options|
       options[:output] = value
     end
+
+    add_option "--ruby-abi RUBY_ABI", "build a content addressable gem for the given Ruby ABI" do |value, options|
+      options[:ruby_abi] = value
+    end
   end
 
   def arguments # :nodoc:
@@ -51,6 +55,10 @@ with gem spec:
 Gems can be saved to a specified filename with the output option:
 
   $ gem build my_gem-1.0.gemspec --output=release.gem
+
+Platform gems can be built for a single Ruby ABI with the --ruby-abi option:
+
+  $ gem build my_gem-1.0.gemspec --ruby-abi=3.4
 
     EOF
   end
@@ -88,7 +96,8 @@ Gems can be saved to a specified filename with the output option:
         spec,
         options[:force],
         options[:strict],
-        options[:output]
+        options[:output],
+        options[:ruby_abi]
       )
     else
       alert_error "Error loading gemspec. Aborting."

--- a/lib/rubygems/package.rb
+++ b/lib/rubygems/package.rb
@@ -133,6 +133,7 @@ class Gem::Package
     require "digest"
     require "stringio"
     io = StringIO.new
+    io.set_encoding(Encoding::BINARY)
     package = new io
     package.spec = spec
     package.build skip_validation, strict_validation
@@ -143,8 +144,28 @@ class Gem::Package
     gem_file
   end
 
-  def self.build(spec, skip_validation = false, strict_validation = false, file_name = nil)
-    if file_name.nil? && spec.content_addressable?
+  def self.validate_or_apply_ruby_abi(spec, ruby_abi)
+    unless /\A\d+\.\d+\z/.match?(ruby_abi)
+      raise ArgumentError, "Ruby ABI must be in X.Y format"
+    end
+
+    if spec.platform.nil? || spec.platform == Gem::Platform::RUBY
+      raise ArgumentError, "Cannot build a gem scoped to a single Ruby ABI as no platform or a Ruby platform has been set"
+    end
+
+    if spec.required_ruby_version.nil? || spec.required_ruby_version == Gem::Requirement.default
+      spec.required_ruby_version = Gem::Requirement.new("~> #{ruby_abi}.0")
+    elsif spec.content_addressable_ruby_abi != ruby_abi
+      raise ArgumentError, "Cannot build a gem scoped to a single Ruby ABI as the required_ruby_version is already set to #{spec.required_ruby_version} which does not match the requested Ruby ABI #{ruby_abi}"
+    end
+  end
+
+  def self.build(spec, skip_validation = false, strict_validation = false, file_name = nil, ruby_abi = nil)
+    if ruby_abi && file_name
+      raise ArgumentError, "Cannot specify both a Ruby ABI and an output file name because content addressable gems must use the generated file name."
+    end
+    if ruby_abi
+      validate_or_apply_ruby_abi(spec, ruby_abi)
       gem_file = build_content_addressable_file(spec, skip_validation, strict_validation)
     else
       gem_file = file_name || spec.file_name

--- a/lib/rubygems/package.rb
+++ b/lib/rubygems/package.rb
@@ -129,13 +129,30 @@ class Gem::Package
   # Permission for other files
   attr_accessor :data_mode
 
-  def self.build(spec, skip_validation = false, strict_validation = false, file_name = nil)
-    gem_file = file_name || spec.file_name
-
-    package = new gem_file
+  def self.build_content_addressable_file(spec, skip_validation, strict_validation)
+    require "digest"
+    require "stringio"
+    io = StringIO.new
+    package = new io
     package.spec = spec
     package.build skip_validation, strict_validation
+    bytes = io.string
+    gem_file = "#{spec.name}-#{spec.version}-#{Digest::SHA256.hexdigest(bytes)[0, 10]}.gem"
+    File.binwrite(gem_file, bytes)
+    package.say "  File: #{gem_file}"
+    gem_file
+  end
 
+  def self.build(spec, skip_validation = false, strict_validation = false, file_name = nil)
+    if file_name.nil? && spec.content_addressable?
+      gem_file = build_content_addressable_file(spec, skip_validation, strict_validation)
+    else
+      gem_file = file_name || spec.file_name
+
+      package = new gem_file
+      package.spec = spec
+      package.build skip_validation, strict_validation
+    end
     gem_file
   end
 
@@ -315,12 +332,14 @@ class Gem::Package
       end
     end
 
-    say <<-EOM
+    message = <<-EOM
   Successfully built RubyGem
   Name: #{@spec.name}
   Version: #{@spec.version}
-  File: #{File.basename @gem.path}
 EOM
+
+    message += "  File: #{File.basename(@gem.path)}\n" if @gem.path
+    say message
   ensure
     @signer = nil
   end

--- a/lib/rubygems/package_task.rb
+++ b/lib/rubygems/package_task.rb
@@ -111,10 +111,10 @@ class Gem::PackageTask < Rake::PackageTask
     file gem_path => [package_dir, gem_dir] + @gem_spec.files do
       chdir(gem_dir) do
         when_writing "Creating #{gem_spec.file_name}" do
-          Gem::Package.build gem_spec
+          built_gem_file = Gem::Package.build gem_spec
 
           verbose trace do
-            mv gem_file, ".."
+            mv built_gem_file, ".."
           end
         end
       end

--- a/lib/rubygems/specification.rb
+++ b/lib/rubygems/specification.rb
@@ -557,6 +557,32 @@ class Gem::Specification < Gem::BasicSpecification
   end
 
   ##
+  # True for platformed gems pinned to a single Ruby ABI
+
+  def content_addressable?
+    return false if platform.nil? || platform == Gem::Platform::RUBY
+
+    !content_addressable_ruby_abi.nil?
+  end
+
+  ##
+  # Helper that returns e.g. "3.3" or nil derived from required_ruby_version
+  # Only supports required_ruby_version in "~> 3.4.0" format for now
+  # Returns nil if the required_ruby_version does not specify a single Ruby ABI
+
+  def content_addressable_ruby_abi
+    return nil if required_ruby_version.nil?
+
+    requirements = required_ruby_version.requirements
+    return nil if requirements.size != 1
+
+    op, version = requirements.first
+    return nil if op != "~>" || version.segments.size != 3
+
+    version.segments[0..1].join(".")
+  end
+
+  ##
   # Executables included in the gem.
   #
   # For example, the rake gem has rake as an executable. You don't specify the

--- a/lib/rubygems/specification.rb
+++ b/lib/rubygems/specification.rb
@@ -557,27 +557,18 @@ class Gem::Specification < Gem::BasicSpecification
   end
 
   ##
-  # True for platformed gems pinned to a single Ruby ABI
-
-  def content_addressable?
-    return false if platform.nil? || platform == Gem::Platform::RUBY
-
-    !content_addressable_ruby_abi.nil?
-  end
-
-  ##
   # Helper that returns e.g. "3.3" or nil derived from required_ruby_version
-  # Only supports required_ruby_version in "~> 3.4.0" format for now
+  # Only supports required_ruby_version in "~> X.Y.0" format (single pessimistic requirement with 3 segments) for now
   # Returns nil if the required_ruby_version does not specify a single Ruby ABI
 
   def content_addressable_ruby_abi
-    return nil if required_ruby_version.nil?
+    return nil if required_ruby_version.nil? || required_ruby_version == Gem::Requirement.default
 
     requirements = required_ruby_version.requirements
     return nil if requirements.size != 1
 
     op, version = requirements.first
-    return nil if op != "~>" || version.segments.size != 3
+    return nil if op != "~>" || version.segments.size != 3 || version.segments[2] != 0
 
     version.segments[0..1].join(".")
   end

--- a/test/rubygems/test_gem_commands_build_command.rb
+++ b/test/rubygems/test_gem_commands_build_command.rb
@@ -43,6 +43,41 @@ class TestGemCommandsBuildCommand < Gem::TestCase
     assert_includes Gem.platforms, Gem::Platform.local
   end
 
+  def test_options_ruby_abi
+    gem = util_spec "platformed_gem" do |s|
+      s.license = "AGPL-3.0-only"
+      s.files = ["README.md"]
+      s.platform = "arm64-darwin"
+      s.required_ruby_version = "~> 3.4.0"
+    end
+
+    gemspec_file = File.join(@tempdir, gem.spec_name)
+
+    File.open gemspec_file, "w" do |gs|
+      gs.write gem.to_ruby
+    end
+
+    @cmd.handle_options [gemspec_file, "--ruby-abi", "3.4"]
+    assert_equal "3.4", @cmd.options[:ruby_abi]
+
+    use_ui @ui do
+      Dir.chdir @tempdir do
+        @cmd.execute
+      end
+    end
+
+    files = Dir[File.join(@tempdir, "platformed_gem-2-*.gem")]
+    assert_equal 1, files.size
+    assert_match(/\Aplatformed_gem-2-[0-9a-f]{10}\.gem\z/, File.basename(files.first))
+
+    output = @ui.output.split "\n"
+    assert_equal "  Successfully built RubyGem", output.shift
+    assert_equal "  Name: platformed_gem", output.shift
+    assert_equal "  Version: 2", output.shift
+    assert_match(/\A  File: platformed_gem-2-[0-9a-f]{10}\.gem\z/, output.shift)
+    assert_equal [], output
+  end
+
   def test_options_filename
     gemspec_file = File.join(@tempdir, @gem.spec_name)
 
@@ -76,6 +111,7 @@ class TestGemCommandsBuildCommand < Gem::TestCase
     refute @cmd.options[:force]
     refute @cmd.options[:strict]
     assert_nil @cmd.options[:output]
+    assert_nil @cmd.options[:ruby_abi]
   end
 
   def test_execute

--- a/test/rubygems/test_gem_package.rb
+++ b/test/rubygems/test_gem_package.rb
@@ -236,6 +236,66 @@ class TestGemPackage < Gem::Package::TarTestCase
     assert_equal [{ "lib/code_sym.rb" => "code.rb" }, { "lib/code_sym2.rb" => "../lib/code.rb" }], symlinks
   end
 
+  def test_content_addressable_spec_creates_content_addressed_file
+    spec = Gem::Specification.new "platformed", "1"
+    spec.summary = "platformed"
+    spec.authors = "platformed"
+    spec.files = ["lib/code.rb"]
+    spec.platform = "arm64-darwin"
+    spec.required_ruby_version = Gem::Requirement.new("~> 3.4.0")
+
+    FileUtils.mkdir "lib"
+
+    File.open "lib/code.rb", "w" do |io|
+      io.write "# lib/code.rb"
+    end
+
+    built_file = Gem::Package.build(spec)
+
+    assert_path_not_exist spec.file_name
+    assert_path_exist built_file
+    assert_match(/\Aplatformed-1-[0-9a-f]{10}\.gem\z/, built_file)
+  end
+
+  def test_non_content_addressable_spec_creates_non_content_addressed_file
+    spec = Gem::Specification.new "non-platformed", "1"
+    spec.summary = "non-platformed"
+    spec.authors = "non-platformed"
+    spec.files = ["lib/code.rb"]
+    spec.required_ruby_version = Gem::Requirement.new("~> 3.4")
+
+    FileUtils.mkdir "lib"
+
+    File.open "lib/code.rb", "w" do |io|
+      io.write "# lib/code.rb"
+    end
+
+    built_file = Gem::Package.build(spec)
+
+    assert_path_exist built_file
+    assert_equal("non-platformed-1.gem", built_file)
+  end
+
+  def test_explicit_output_keeps_requested_filename
+    spec = Gem::Specification.new "explicit", "1"
+    spec.summary = "explicit"
+    spec.authors = "explicit"
+    spec.files = ["lib/code.rb"]
+    spec.platform = "arm64-darwin"
+    spec.required_ruby_version = Gem::Requirement.new("~> 3.4.0")
+
+    FileUtils.mkdir "lib"
+
+    File.open "lib/code.rb", "w" do |io|
+      io.write "# lib/code.rb"
+    end
+
+    built_file = Gem::Package.build(spec, false, false, "explicit-output.gem")
+
+    assert_path_exist built_file
+    assert_equal("explicit-output.gem", built_file)
+  end
+
   def test_build
     spec = Gem::Specification.new "build", "1"
     spec.summary = "build"

--- a/test/rubygems/test_gem_package.rb
+++ b/test/rubygems/test_gem_package.rb
@@ -236,7 +236,28 @@ class TestGemPackage < Gem::Package::TarTestCase
     assert_equal [{ "lib/code_sym.rb" => "code.rb" }, { "lib/code_sym2.rb" => "../lib/code.rb" }], symlinks
   end
 
-  def test_content_addressable_spec_creates_content_addressed_file
+  def test_ruby_abi_creates_content_addressed_file
+    spec = Gem::Specification.new "platformed", "1"
+    spec.summary = "platformed"
+    spec.authors = "platformed"
+    spec.files = ["lib/code.rb"]
+    spec.platform = "arm64-darwin"
+    spec.required_ruby_version = Gem::Requirement.new("~> 3.4.0")
+
+    FileUtils.mkdir "lib"
+
+    File.open "lib/code.rb", "w" do |io|
+      io.write "# lib/code.rb"
+    end
+
+    built_file = Gem::Package.build(spec, false, false, nil, "3.4")
+
+    assert_path_not_exist spec.file_name
+    assert_path_exist built_file
+    assert_match(/\Aplatformed-1-[0-9a-f]{10}\.gem\z/, built_file)
+  end
+
+  def test_ruby_abi_not_passed_does_not_create_content_addressed_file
     spec = Gem::Specification.new "platformed", "1"
     spec.summary = "platformed"
     spec.authors = "platformed"
@@ -252,12 +273,75 @@ class TestGemPackage < Gem::Package::TarTestCase
 
     built_file = Gem::Package.build(spec)
 
-    assert_path_not_exist spec.file_name
     assert_path_exist built_file
-    assert_match(/\Aplatformed-1-[0-9a-f]{10}\.gem\z/, built_file)
+    assert_equal("platformed-1-arm64-darwin.gem", built_file)
   end
 
-  def test_non_content_addressable_spec_creates_non_content_addressed_file
+  def test_required_ruby_version_is_set_by_ruby_abi_if_default
+    spec = Gem::Specification.new "platformed", "1"
+    spec.summary = "platformed"
+    spec.authors = "platformed"
+    spec.files = ["lib/code.rb"]
+    spec.platform = "arm64-darwin"
+    spec.required_ruby_version = Gem::Requirement.default
+
+    FileUtils.mkdir "lib"
+
+    File.open "lib/code.rb", "w" do |io|
+      io.write "# lib/code.rb"
+    end
+
+    built_file = Gem::Package.build(spec, false, false, nil, "3.4")
+
+    assert_path_exist built_file
+    assert_match(/\Aplatformed-1-[0-9a-f]{10}\.gem\z/, built_file)
+    assert_equal Gem::Requirement.new("~> 3.4.0"), spec.required_ruby_version
+  end
+
+  def test_raise_if_required_ruby_version_conflicts_with_ruby_abi
+    spec = Gem::Specification.new "platformed", "1"
+    spec.summary = "platformed"
+    spec.authors = "platformed"
+    spec.files = ["lib/code.rb"]
+    spec.platform = "arm64-darwin"
+    spec.required_ruby_version = Gem::Requirement.new("~> 3.5.0")
+
+    FileUtils.mkdir "lib"
+
+    File.open "lib/code.rb", "w" do |io|
+      io.write "# lib/code.rb"
+    end
+
+    e = assert_raise ArgumentError do
+      Gem::Package.build(spec, false, false, nil, "3.4")
+    end
+
+    assert_match "required_ruby_version is already set to ~> 3.5.0", e.message
+    assert_match "requested Ruby ABI 3.4", e.message
+  end
+
+  def test_raise_if_ruby_abi_is_not_in_x_y_format
+    spec = Gem::Specification.new "platformed", "1"
+    spec.summary = "platformed"
+    spec.authors = "platformed"
+    spec.files = ["lib/code.rb"]
+    spec.platform = "arm64-darwin"
+    spec.required_ruby_version = Gem::Requirement.new("~> 3.4.0")
+
+    FileUtils.mkdir "lib"
+
+    File.open "lib/code.rb", "w" do |io|
+      io.write "# lib/code.rb"
+    end
+
+    e = assert_raise ArgumentError do
+      Gem::Package.build(spec, false, false, nil, "3.4.5")
+    end
+
+    assert_match "Ruby ABI must be in X.Y format", e.message
+  end
+
+  def test_raise_if_spec_is_non_platformed_but_ruby_abi_is_passed
     spec = Gem::Specification.new "non-platformed", "1"
     spec.summary = "non-platformed"
     spec.authors = "non-platformed"
@@ -270,10 +354,11 @@ class TestGemPackage < Gem::Package::TarTestCase
       io.write "# lib/code.rb"
     end
 
-    built_file = Gem::Package.build(spec)
+    e = assert_raise ArgumentError do
+      Gem::Package.build(spec, false, false, nil, "3.4")
+    end
 
-    assert_path_exist built_file
-    assert_equal("non-platformed-1.gem", built_file)
+    assert_match "no platform or a Ruby platform has been set", e.message
   end
 
   def test_explicit_output_keeps_requested_filename
@@ -294,6 +379,29 @@ class TestGemPackage < Gem::Package::TarTestCase
 
     assert_path_exist built_file
     assert_equal("explicit-output.gem", built_file)
+  end
+
+  def test_explicit_output_and_ruby_abi_raises
+    spec = Gem::Specification.new "explicit", "1"
+    spec.summary = "explicit"
+    spec.authors = "explicit"
+    spec.files = ["lib/code.rb"]
+    spec.platform = "arm64-darwin"
+    spec.required_ruby_version = Gem::Requirement.default
+
+    FileUtils.mkdir "lib"
+
+    File.open "lib/code.rb", "w" do |io|
+      io.write "# lib/code.rb"
+    end
+
+    e = assert_raise ArgumentError do
+      Gem::Package.build(spec, false, false, "explicit-output.gem", "3.4")
+    end
+
+    assert_match "Cannot specify both a Ruby ABI and an output file name", e.message
+    assert_equal Gem::Requirement.default, spec.required_ruby_version
+    assert_path_not_exist "explicit-output.gem"
   end
 
   def test_build

--- a/test/rubygems/test_gem_package_task.rb
+++ b/test/rubygems/test_gem_package_task.rb
@@ -43,6 +43,41 @@ class TestGemPackageTask < Gem::TestCase
     RakeFileUtils.verbose_flag = original_rake_fileutils_verbosity
   end
 
+  def test_moves_content_addressable_filename_returned_by_build
+    gem = Gem::Specification.new do |g|
+      g.name = "pkgr"
+      g.version = "1.2.3"
+      g.platform = "arm64-darwin"
+      g.required_ruby_version = "~> 3.4.0"
+
+      g.authors = %w[author]
+      g.files = %w[x]
+      g.summary = "summary"
+    end
+
+    Rake.application = Rake::Application.new
+
+    pkg = Gem::PackageTask.new(gem) do |p|
+      p.package_files << "y"
+    end
+
+    assert_equal %w[x y], pkg.package_files
+
+    Dir.chdir @tempdir do
+      FileUtils.touch "x"
+      FileUtils.touch "y"
+
+      Rake.application["package"].invoke
+
+      built_files = Dir["pkg/pkgr-1.2.3-*.gem"]
+
+      assert_equal 1, built_files.length
+      assert_match %r{\Apkg/pkgr-1\.2\.3-[0-9a-f]{10}\.gem\z}, built_files.first
+      assert_path_exist built_files.first
+      assert_path_not_exist "pkg/pkgr-1.2.3-arm64-darwin.gem"
+    end
+  end
+
   def test_gem_package_prints_to_stdout_by_default
     gem = Gem::Specification.new do |g|
       g.name = "pkgr"

--- a/test/rubygems/test_gem_package_task.rb
+++ b/test/rubygems/test_gem_package_task.rb
@@ -43,7 +43,7 @@ class TestGemPackageTask < Gem::TestCase
     RakeFileUtils.verbose_flag = original_rake_fileutils_verbosity
   end
 
-  def test_moves_content_addressable_filename_returned_by_build
+  def test_moves_filename_returned_by_build
     gem = Gem::Specification.new do |g|
       g.name = "pkgr"
       g.version = "1.2.3"
@@ -67,13 +67,19 @@ class TestGemPackageTask < Gem::TestCase
       FileUtils.touch "x"
       FileUtils.touch "y"
 
-      Rake.application["package"].invoke
+      built_gem_file = "pkgr-1.2.3-0123456789.gem"
+
+      Gem::Package.stub :build, ->(_) {
+        FileUtils.touch built_gem_file
+        built_gem_file
+      } do
+        Rake.application["package"].invoke
+      end
 
       built_files = Dir["pkg/pkgr-1.2.3-*.gem"]
 
       assert_equal 1, built_files.length
-      assert_match %r{\Apkg/pkgr-1\.2\.3-[0-9a-f]{10}\.gem\z}, built_files.first
-      assert_path_exist built_files.first
+      assert_equal "pkg/pkgr-1.2.3-0123456789.gem", built_files.first
       assert_path_not_exist "pkg/pkgr-1.2.3-arm64-darwin.gem"
     end
   end

--- a/test/rubygems/test_gem_specification.rb
+++ b/test/rubygems/test_gem_specification.rb
@@ -1907,6 +1907,57 @@ dependencies: []
     assert_equal expected, @a1.full_gem_path
   end
 
+  def test_content_addressable_returns_true_for_platformed_gem_pinned_to_single_ruby_abi
+    spec = Gem::Specification.new
+    spec.required_ruby_version = "~> 3.4.0"
+    spec.platform = "arm64-darwin"
+    assert spec.content_addressable?
+  end
+
+  def test_content_addressable_returns_false_for_non_platformed_gem_pinned_to_single_ruby_abi
+    spec = Gem::Specification.new
+    spec.required_ruby_version = "~> 3.4.0"
+    spec.platform = Gem::Platform::RUBY
+    refute spec.content_addressable?
+  end
+
+  def test_content_addressable_returns_false_for_platformed_gem_not_pinned_to_single_ruby_abi
+    spec = Gem::Specification.new
+    spec.required_ruby_version = ["~> 3.4.0", "~> 3.5.0"]
+    spec.platform = "arm64-darwin"
+    refute spec.content_addressable?
+  end
+
+  def test_ruby_abi_derived_from_required_ruby_version
+    spec = Gem::Specification.new
+    spec.required_ruby_version = "~> 3.4.0"
+    assert_equal "3.4", spec.content_addressable_ruby_abi
+  end
+
+  def test_ruby_abi_returns_nil_for_pessimistic_requirement_without_patch_segment
+    spec = Gem::Specification.new
+    spec.required_ruby_version = "~> 3.4"
+    assert_nil spec.content_addressable_ruby_abi
+  end
+
+  def test_ruby_abi_returns_nil_for_non_single_ruby_abi_requirement
+    spec = Gem::Specification.new
+    spec.required_ruby_version = ["< 3.4", ">= 3.2"]
+    assert_nil spec.content_addressable_ruby_abi
+  end
+
+  def test_ruby_abi_returns_nil_for_non_single_ruby_abi_requirement_with_dev_version
+    spec = Gem::Specification.new
+    spec.required_ruby_version = "~> 3.4.0.dev"
+    assert_nil spec.content_addressable_ruby_abi
+  end
+
+  def test_ruby_abi_returns_nil_for_non_pessimistic_operator
+    spec = Gem::Specification.new
+    spec.required_ruby_version = ">= 3.4.0"
+    assert_nil spec.content_addressable_ruby_abi
+  end
+
   def test_full_name
     assert_equal "a-1", @a1.full_name
 

--- a/test/rubygems/test_gem_specification.rb
+++ b/test/rubygems/test_gem_specification.rb
@@ -1907,27 +1907,6 @@ dependencies: []
     assert_equal expected, @a1.full_gem_path
   end
 
-  def test_content_addressable_returns_true_for_platformed_gem_pinned_to_single_ruby_abi
-    spec = Gem::Specification.new
-    spec.required_ruby_version = "~> 3.4.0"
-    spec.platform = "arm64-darwin"
-    assert spec.content_addressable?
-  end
-
-  def test_content_addressable_returns_false_for_non_platformed_gem_pinned_to_single_ruby_abi
-    spec = Gem::Specification.new
-    spec.required_ruby_version = "~> 3.4.0"
-    spec.platform = Gem::Platform::RUBY
-    refute spec.content_addressable?
-  end
-
-  def test_content_addressable_returns_false_for_platformed_gem_not_pinned_to_single_ruby_abi
-    spec = Gem::Specification.new
-    spec.required_ruby_version = ["~> 3.4.0", "~> 3.5.0"]
-    spec.platform = "arm64-darwin"
-    refute spec.content_addressable?
-  end
-
   def test_ruby_abi_derived_from_required_ruby_version
     spec = Gem::Specification.new
     spec.required_ruby_version = "~> 3.4.0"
@@ -1937,6 +1916,12 @@ dependencies: []
   def test_ruby_abi_returns_nil_for_pessimistic_requirement_without_patch_segment
     spec = Gem::Specification.new
     spec.required_ruby_version = "~> 3.4"
+    assert_nil spec.content_addressable_ruby_abi
+  end
+
+  def test_ruby_abi_returns_nil_for_pessimistic_requirement_with_nonzero_patch_segment
+    spec = Gem::Specification.new
+    spec.required_ruby_version = "~> 3.4.1"
     assert_nil spec.content_addressable_ruby_abi
   end
 


### PR DESCRIPTION
### TL;DR

As part of the work to speed up `bundle install`, this PR adjusts `gem build` to support using content-addressable naming at build-time for a gem which only supports a single Ruby ABI.

### Summary

This PR introduces changes to the `gem build` process to assign a content-addressable file name during the build of a gem that only supports one Ruby ABI (a skinny gem). 

The bulk of the changes are in `Gem::Package`. In `self.build`, we now check if the `ruby_abi` flag has been set when the `gem build` command is run. Only if it has do we first validate the Ruby ABI value (and compare this to the `required_ruby_version` for compatibility etc.) and then build a content addressable file if the validation passes without raising. If the user has passed a file name value at time of running `gem build`, we raise, as we would not expect a content addressable gem to have a custom file name (it instead has a SHA value based on the file contents). As part of the CA file name compilation, we build the gem first in memory (using `StringIO.new`), generate the SHA value from the file contents, and then write the file including the SHA value as the filename.

There is also a minor change to `package_task` which ensures that we are eventually transferring the correct file output of the build (as now the name could take three different forms - standard, platformed or content addressed), and a helper method in `specification.rb` which helps compare the Ruby ABI to the `required_ruby_version` provided.  

### Testing

Tests written in `test_gem_commands_build_command`, `test_gem_package`, `test_gem_package_task`, and `test_gem_specification` to cover new behaviour. 

### Tophat

Within IRB terminal, paste this script so you can see the output of using the `Gem::Package.build` command in different scenarios: 

```
require "rubygems/package"
  require "tmpdir"

  Dir.mktmpdir do |dir|
    Dir.chdir(dir) do
      Dir.mkdir("lib")
      File.write("lib/code.rb", "# hello\n")

      def spec(name, ruby_version: "~> 3.4.0", platform: "arm64-darwin")
        Gem::Specification.new(name, "1") do |s|
          s.summary = name
          s.authors = ["reviewer"]
          s.files = ["lib/code.rb"]
          s.platform = platform
          s.required_ruby_version = ruby_version if ruby_version
        end
      end

      puts "\n1. Explicit ruby_abi builds content-addressed filename"
      Gem::Package.build(spec("skinny"), false, false, nil, "3.4")
      p Dir["skinny-1-*.gem"]

      puts "\n2. No ruby_abi keeps normal platform filename"
      Gem::Package.build(spec("normal"))
      p Dir["normal-1-*.gem"]

      puts "\n3. Missing required_ruby_version is filled from ruby_abi"
      defaulted = spec("defaulted", ruby_version: nil)
      Gem::Package.build(defaulted, false, false, nil, "3.4")
      p Dir["defaulted-1-*.gem"]
      p defaulted.required_ruby_version

      puts "\n4. Conflicting required_ruby_version raises"
      begin
        Gem::Package.build(spec("bad", ruby_version: "~> 3.5.0"), false, false, nil, "3.4")
      rescue ArgumentError => e
        puts e.message
      end

      puts "\nBuilt files:"
      puts Dir["*.gem"].sort
    end
  end
```

To try the `gem build` command locally against this branch, you can run it through the RubyGems checkout rather than your installed RubyGems. From a test gem directory with a platformed gemspec, use: `ruby --disable-gems -I/path/to/rubygems/lib /path/to/rubygems/exe/gem build *.gemspec --ruby-abi 3.4.` As an example, for my checkout that is: `ruby --disable-gems -I/Users/harrietoughton/rubygems/lib /Users/harrietoughton/rubygems/exe/gem build *.gemspec --ruby-abi 3.4.` 

The single Ruby ABI built file should be named `<name>-<version>-<sha10>.gem` rather than `<name>-<version>-<platform>.gem.` It's also worth testing out that you receive the expected behaviour with a wrong format ruby ABI (e.g. `--ruby-abi 3`), with a mismatched Ruby ABI and `required_ruby_version` and when a gem is platformed with no Ruby ABI and when it is neither platformed nor intended for a single ABI. 