### PR TITLE
[Content Addressable] Support Content Addressable Gems in Local Install Process

### DIFF
--- a/Manifest.txt
+++ b/Manifest.txt
@@ -367,6 +367,7 @@ lib/rubygems/compact_index_client/http_fetcher.rb
 lib/rubygems/compact_index_client/parser.rb
 lib/rubygems/compact_index_client/updater.rb
 lib/rubygems/config_file.rb
+lib/rubygems/content_address.rb
 lib/rubygems/core_ext/kernel_gem.rb
 lib/rubygems/core_ext/kernel_require.rb
 lib/rubygems/core_ext/kernel_warn.rb

--- a/lib/rubygems.rb
+++ b/lib/rubygems.rb
@@ -1411,6 +1411,7 @@ An Array (#{env.inspect}) was passed in from #{caller[3]}
   MARSHAL_SPEC_DIR = "quick/Marshal.#{Gem.marshal_version}/".freeze
 
   autoload :ConfigFile,         File.expand_path("rubygems/config_file", __dir__)
+  autoload :ContentAddress,     File.expand_path("rubygems/content_address", __dir__)
   autoload :CIDetector,         File.expand_path("rubygems/ci_detector", __dir__)
   autoload :Dependency,         File.expand_path("rubygems/dependency", __dir__)
   autoload :DependencyList,     File.expand_path("rubygems/dependency_list", __dir__)

--- a/lib/rubygems/basic_specification.rb
+++ b/lib/rubygems/basic_specification.rb
@@ -140,16 +140,33 @@ class Gem::BasicSpecification
   end
 
   ##
-  # Returns the full name (name-version) of this Gem.  Platform information
-  # is included (name-version-platform) if it is specified and not the
+  # Returns the full name (name-version) of this Gem.
+  # Content address is included (name-version-content_address) if it is specified.
+  # Platform information is included (name-version-platform) if it is specified and not the
   # default Ruby platform.
 
   def full_name
-    if platform == Gem::Platform::RUBY || platform.nil?
+    if content_addressable?
+      "#{name}-#{version}-#{content_address}"
+    elsif platform == Gem::Platform::RUBY || platform.nil?
       "#{name}-#{version}"
     else
       "#{name}-#{version}-#{platform}"
     end
+  end
+
+  def content_address # :nodoc:
+    raise NotImplementedError
+  end
+
+  def content_addressable? # :nodoc:
+    Gem::BasicSpecification.content_address?(content_address)
+  end
+
+  CONTENT_ADDRESS = /\A[0-9a-f]{8,64}\z/ # :nodoc:
+
+  def self.content_address?(value) # :nodoc:
+    value.is_a?(String) && CONTENT_ADDRESS.match?(value)
   end
 
   ##

--- a/lib/rubygems/basic_specification.rb
+++ b/lib/rubygems/basic_specification.rb
@@ -141,12 +141,13 @@ class Gem::BasicSpecification
 
   ##
   # Returns the full name (name-version) of this Gem.
-  # Content address is included (name-version-content_address) if it is specified.
+  # Content address is included (name-version-content_address) if the gem
+  # is content-addressed (eligible and has a valid content address).
   # Platform information is included (name-version-platform) if it is specified and not the
   # default Ruby platform.
 
   def full_name
-    if content_addressable?
+    if Gem::ContentAddress.content_addressed?(self)
       "#{name}-#{version}-#{content_address}"
     elsif platform == Gem::Platform::RUBY || platform.nil?
       "#{name}-#{version}"
@@ -157,16 +158,6 @@ class Gem::BasicSpecification
 
   def content_address # :nodoc:
     raise NotImplementedError
-  end
-
-  def content_addressable? # :nodoc:
-    Gem::BasicSpecification.content_address?(content_address)
-  end
-
-  CONTENT_ADDRESS = /\A[0-9a-f]{8,64}\z/ # :nodoc:
-
-  def self.content_address?(value) # :nodoc:
-    value.is_a?(String) && CONTENT_ADDRESS.match?(value)
   end
 
   ##

--- a/lib/rubygems/content_address.rb
+++ b/lib/rubygems/content_address.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+##
+# Gem::ContentAddress encapsulates the pattern for recognizing
+# content-addressable gem file names.
+
+module Gem::ContentAddress
+  # :nodoc:
+  PATTERN = /\A[0-9a-f]{8,64}\z/
+
+  ##
+  # Whether +spec+ is eligible for content addressing. A gem must
+  # pin a required_ruby_version and declare a non-RUBY platform to be
+  # content addressed.
+
+  def self.applicable?(spec)
+    spec.required_ruby_version.to_s != ">= 0" &&
+      !spec.platform.nil? && spec.platform != Gem::Platform::RUBY
+  end
+
+  ##
+  # Whether +spec+ is content-addressed: it is eligible for content
+  # addressing and has a valid content address set.
+
+  def self.content_addressed?(spec)
+    applicable?(spec) && match?(spec.content_address)
+  end
+
+  ##
+  # Whether +value+ is a valid content address (a string of 8-64
+  # lowercase hexadecimal characters).
+
+  def self.match?(value)
+    value.is_a?(String) && PATTERN.match?(value)
+  end
+end

--- a/lib/rubygems/installer.rb
+++ b/lib/rubygems/installer.rb
@@ -114,6 +114,9 @@ class Gem::Installer
 
     def copy_to(path)
     end
+
+    def gem
+    end
   end
 
   ##
@@ -266,6 +269,7 @@ class Gem::Installer
   #     specifications/<gem-version>.gemspec #=> the Gem::Specification
 
   def install
+    assign_content_address
     pre_install_checks
 
     run_pre_install_hooks
@@ -965,6 +969,26 @@ class Gem::Installer
   end
 
   private
+
+  def assign_content_address
+    path = @package.gem&.path
+    address = derive_content_address_from_filename(path)
+    @gem_dir = nil if address != spec.content_address
+    spec.content_address = address
+  end
+
+  def derive_content_address_from_filename(path)
+    return unless path
+
+    filename = File.basename(path, ".gem")
+    token = filename.split("-").last
+    return nil unless Gem::BasicSpecification.content_address?(token)
+
+    require "digest"
+    digest = Digest::SHA256.file(path).hexdigest
+    raise Gem::InstallError, "content address mismatch for #{File.basename(path)}" unless digest.start_with?(token)
+    token
+  end
 
   def user_install_dir
     # never install to user home in --build-root mode

--- a/lib/rubygems/installer.rb
+++ b/lib/rubygems/installer.rb
@@ -117,6 +117,9 @@ class Gem::Installer
 
     def gem
     end
+
+    def content_address
+    end
   end
 
   ##
@@ -971,23 +974,9 @@ class Gem::Installer
   private
 
   def assign_content_address
-    path = @package.gem&.path
-    address = derive_content_address_from_filename(path)
+    address = @package.content_address
     @gem_dir = nil if address != spec.content_address
     spec.content_address = address
-  end
-
-  def derive_content_address_from_filename(path)
-    return unless path
-
-    filename = File.basename(path, ".gem")
-    token = filename.split("-").last
-    return nil unless Gem::BasicSpecification.content_address?(token)
-
-    require "digest"
-    digest = Digest::SHA256.file(path).hexdigest
-    raise Gem::InstallError, "content address mismatch for #{File.basename(path)}" unless digest.start_with?(token)
-    token
   end
 
   def user_install_dir

--- a/lib/rubygems/package.rb
+++ b/lib/rubygems/package.rb
@@ -255,6 +255,28 @@ class Gem::Package
   end
 
   ##
+  # Derives the content address from the gem's file name and verifies it
+  # against the SHA256 digest of the file contents.
+
+  def content_address
+    path = @gem&.path
+    return unless path
+
+    return nil unless Gem::ContentAddress.applicable?(spec)
+
+    filename = File.basename(path, ".gem")
+    base = "#{spec.name}-#{spec.version}"
+    suffix = filename.delete_prefix("#{base}-")
+    return nil if suffix == filename
+    return nil unless Gem::ContentAddress.match?(suffix)
+
+    require "digest"
+    digest = Digest::SHA256.file(path).hexdigest
+    raise Gem::InstallError, "content address mismatch for #{File.basename(path)}" unless digest.start_with?(suffix)
+    suffix
+  end
+
+  ##
   # Adds a checksum for each entry in the gem to checksums.yaml.gz.
 
   def add_checksums(tar)

--- a/lib/rubygems/specification.rb
+++ b/lib/rubygems/specification.rb
@@ -2402,11 +2402,12 @@ class Gem::Specification < Gem::BasicSpecification
   # still have their default values are omitted.
 
   def to_ruby
-    gem_suffix = content_addressable? ? content_address : platform
+    content_addressed = Gem::ContentAddress.content_addressed?(self)
+    gem_suffix = content_addressed ? content_address : platform
     result = []
     result << "# -*- encoding: utf-8 -*-"
     result << "#{Gem::StubSpecification::PREFIX}#{name} #{version} #{gem_suffix} #{raw_require_paths.join("\0")}"
-    result << "#{Gem::StubSpecification::TARGET_PREFIX}platform=#{platform}" if content_addressable?
+    result << "#{Gem::StubSpecification::TARGET_PREFIX}platform=#{platform}" if content_addressed
     result << "#{Gem::StubSpecification::PREFIX}#{extensions.join "\0"}" unless
       extensions.empty?
     result << nil
@@ -2417,7 +2418,7 @@ class Gem::Specification < Gem::BasicSpecification
     unless platform.nil? || platform == Gem::Platform::RUBY
       result << "  s.platform = #{ruby_code original_platform}"
     end
-    result << "  s.content_address = #{ruby_code content_address} if s.respond_to? :content_address=" if content_addressable?
+    result << "  s.content_address = #{ruby_code content_address} if s.respond_to? :content_address=" if content_addressed
     result << ""
     result << "  s.required_rubygems_version = #{ruby_code required_rubygems_version} if s.respond_to? :required_rubygems_version="
 

--- a/lib/rubygems/specification.rb
+++ b/lib/rubygems/specification.rb
@@ -419,6 +419,8 @@ class Gem::Specification < Gem::BasicSpecification
 
   attr_accessor :metadata
 
+  attr_accessor :content_address # :nodoc:
+
   ######################################################################
   # :section: Optional gemspec attributes
 
@@ -1371,7 +1373,8 @@ class Gem::Specification < Gem::BasicSpecification
     self.class === other &&
       name == other.name &&
       version == other.version &&
-      platform == other.platform
+      platform == other.platform &&
+      content_address == other.content_address
   end
 
   ##
@@ -1942,7 +1945,7 @@ class Gem::Specification < Gem::BasicSpecification
   # :startdoc:
 
   def hash # :nodoc:
-    name.hash ^ version.hash
+    [name, version, platform, content_address].hash
   end
 
   def init_with(coder) # :nodoc:
@@ -1978,6 +1981,7 @@ class Gem::Specification < Gem::BasicSpecification
     @loaded_from = nil
     @original_platform = nil
     @installed_by_version = nil
+    @content_address = nil
 
     set_nil_attributes_to_nil
     set_not_nil_attributes_to_default_values
@@ -2298,7 +2302,8 @@ class Gem::Specification < Gem::BasicSpecification
   # True if this gem has the same attributes as +other+.
 
   def same_attributes?(spec)
-    @@attributes.all? {|name, _default| send(name) == spec.send(name) }
+    @@attributes.all? {|name, _default| send(name) == spec.send(name) } &&
+      content_address == spec.content_address
   end
 
   private :same_attributes?
@@ -2397,9 +2402,11 @@ class Gem::Specification < Gem::BasicSpecification
   # still have their default values are omitted.
 
   def to_ruby
+    gem_suffix = content_addressable? ? content_address : platform
     result = []
     result << "# -*- encoding: utf-8 -*-"
-    result << "#{Gem::StubSpecification::PREFIX}#{name} #{version} #{platform} #{raw_require_paths.join("\0")}"
+    result << "#{Gem::StubSpecification::PREFIX}#{name} #{version} #{gem_suffix} #{raw_require_paths.join("\0")}"
+    result << "#{Gem::StubSpecification::TARGET_PREFIX}platform=#{platform}" if content_addressable?
     result << "#{Gem::StubSpecification::PREFIX}#{extensions.join "\0"}" unless
       extensions.empty?
     result << nil
@@ -2410,6 +2417,7 @@ class Gem::Specification < Gem::BasicSpecification
     unless platform.nil? || platform == Gem::Platform::RUBY
       result << "  s.platform = #{ruby_code original_platform}"
     end
+    result << "  s.content_address = #{ruby_code content_address} if s.respond_to? :content_address=" if content_addressable?
     result << ""
     result << "  s.required_rubygems_version = #{ruby_code required_rubygems_version} if s.respond_to? :required_rubygems_version="
 

--- a/lib/rubygems/stub_specification.rb
+++ b/lib/rubygems/stub_specification.rb
@@ -10,11 +10,14 @@ class Gem::StubSpecification < Gem::BasicSpecification
   PREFIX = "# stub: "
 
   # :nodoc:
+  TARGET_PREFIX = "# stub-target: "
+
+  # :nodoc:
   OPEN_MODE = "r:UTF-8:-"
 
   class StubLine # :nodoc: all
     attr_reader :name, :version, :platform, :require_paths, :extensions,
-                :full_name
+                :full_name, :content_address
 
     NO_EXTENSIONS = [].freeze
 
@@ -33,7 +36,7 @@ class Gem::StubSpecification < Gem::BasicSpecification
       "lib" => ["lib"].freeze,
     }.freeze
 
-    def initialize(data, extensions)
+    def initialize(data, extensions, target = nil)
       parts          = data[PREFIX.length..-1].split(" ", 4)
       @name          = -parts[0]
       @version       = if Gem::Version.correct?(parts[1])
@@ -42,12 +45,17 @@ class Gem::StubSpecification < Gem::BasicSpecification
         Gem::Version.new(0)
       end
 
-      @platform      = Gem::Platform.new parts[2]
+      suffix = parts[2]
+      target_platform = target && target["platform"]
+      @platform = Gem::Platform.new(target_platform || suffix)
+      @content_address = suffix if Gem::BasicSpecification.content_address?(suffix)
       @extensions    = extensions
-      @full_name     = if platform == Gem::Platform::RUBY
+      @full_name     = if @content_address
+        "#{name}-#{version}-#{content_address}"
+      elsif platform == Gem::Platform::RUBY
         "#{name}-#{version}"
       else
-        "#{name}-#{version}-#{platform}"
+        "#{name}-#{version}-#{suffix}"
       end
 
       path_list = parts.last
@@ -110,18 +118,28 @@ class Gem::StubSpecification < Gem::BasicSpecification
           file.readline # discard encoding line
           stubline = file.readline
           if stubline.start_with?(PREFIX)
-            extline = file.readline
+            line = file.readline
+
+            if line.delete_prefix!(TARGET_PREFIX)
+              line.chomp!
+              target = {}
+              line.split(",").each do |pair|
+                key, value = pair.split("=", 2)
+                target[key] = value
+              end
+              line = file.readline
+            end
 
             extensions =
-              if extline.delete_prefix!(PREFIX)
-                extline.chomp!
-                extline.split "\0"
+              if line.delete_prefix!(PREFIX)
+                line.chomp!
+                line.split "\0"
               else
                 StubLine::NO_EXTENSIONS
               end
 
             stubline.chomp! # readline(chomp: true) allocates 3x as much as .readline.chomp!
-            @data = StubLine.new stubline, extensions
+            @data = StubLine.new stubline, extensions, target
           end
         rescue EOFError
         end
@@ -160,6 +178,10 @@ class Gem::StubSpecification < Gem::BasicSpecification
 
   def platform
     data.platform
+  end
+
+  def content_address # :nodoc:
+    data.content_address
   end
 
   ##
@@ -208,13 +230,14 @@ class Gem::StubSpecification < Gem::BasicSpecification
     self.class === other &&
       name == other.name &&
       version == other.version &&
-      platform == other.platform
+      platform == other.platform &&
+      content_address == other.content_address
   end
 
   alias_method :eql?, :== # :nodoc:
 
   def hash # :nodoc:
-    name.hash ^ version.hash ^ platform.hash
+    [name, version, platform, content_address].hash
   end
 
   def <=>(other) # :nodoc:

--- a/lib/rubygems/stub_specification.rb
+++ b/lib/rubygems/stub_specification.rb
@@ -48,7 +48,7 @@ class Gem::StubSpecification < Gem::BasicSpecification
       suffix = parts[2]
       target_platform = target && target["platform"]
       @platform = Gem::Platform.new(target_platform || suffix)
-      @content_address = suffix if Gem::BasicSpecification.content_address?(suffix)
+      @content_address = suffix if Gem::ContentAddress.match?(suffix)
       @extensions    = extensions
       @full_name     = if @content_address
         "#{name}-#{version}-#{content_address}"

--- a/test/rubygems/test_gem_content_address.rb
+++ b/test/rubygems/test_gem_content_address.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+require_relative "helper"
+require "rubygems/content_address"
+
+class TestGemContentAddress < Gem::TestCase
+  def test_match
+    assert Gem::ContentAddress.match?("abcdef12")
+    refute Gem::ContentAddress.match?("x86_64-linux")
+    refute Gem::ContentAddress.match?(nil)
+    refute Gem::ContentAddress.match?("abc")
+  end
+
+  def test_match_boundary_lengths
+    assert Gem::ContentAddress.match?("a" * 8)
+    assert Gem::ContentAddress.match?("a" * 64)
+    refute Gem::ContentAddress.match?("a" * 7)
+    refute Gem::ContentAddress.match?("a" * 65)
+  end
+
+  def test_match_rejects_uppercase
+    refute Gem::ContentAddress.match?("ABCDEF12")
+  end
+
+  def test_applicable_with_required_ruby_version_and_platform
+    spec = Gem::Specification.new "a", 1
+    spec.required_ruby_version = ">= 3.0"
+    spec.platform = "x86_64-linux"
+    assert Gem::ContentAddress.applicable?(spec)
+  end
+
+  def test_applicable_without_required_ruby_version
+    spec = Gem::Specification.new "a", 1
+    spec.platform = "x86_64-linux"
+    refute Gem::ContentAddress.applicable?(spec)
+  end
+
+  def test_applicable_with_ruby_platform
+    spec = Gem::Specification.new "a", 1
+    spec.required_ruby_version = ">= 3.0"
+    refute Gem::ContentAddress.applicable?(spec)
+  end
+
+  def test_applicable_with_nil_platform
+    spec = Gem::Specification.new "a", 1
+    spec.required_ruby_version = ">= 3.0"
+    spec.platform = nil
+    refute Gem::ContentAddress.applicable?(spec)
+  end
+
+  def test_content_addressed_with_eligible_spec_and_valid_address
+    spec = Gem::Specification.new "a", 1
+    spec.required_ruby_version = ">= 3.0"
+    spec.platform = "x86_64-linux"
+    spec.content_address = "abcdef12"
+    assert Gem::ContentAddress.content_addressed?(spec)
+  end
+
+  def test_content_addressed_with_eligible_spec_and_no_address
+    spec = Gem::Specification.new "a", 1
+    spec.required_ruby_version = ">= 3.0"
+    spec.platform = "x86_64-linux"
+    refute Gem::ContentAddress.content_addressed?(spec)
+  end
+
+  def test_content_addressed_with_ineligible_spec_and_valid_address
+    spec = Gem::Specification.new "a", 1
+    spec.content_address = "abcdef12"
+    refute Gem::ContentAddress.content_addressed?(spec)
+  end
+end

--- a/test/rubygems/test_gem_installer.rb
+++ b/test/rubygems/test_gem_installer.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require_relative "installer_test_case"
+require "digest"
 
 class TestGemInstaller < Gem::InstallerTestCase
   def setup
@@ -1028,6 +1029,92 @@ class TestGemInstaller < Gem::InstallerTestCase
 
     assert_path_exist File.join(gemhome2, "gems", @spec.full_name)
     assert_path_not_exist File.join(Gem.user_dir, "gems", @spec.full_name)
+  end
+
+  def test_install_assigns_content_address_from_filename
+    _, a_gem = util_gem "a", 2
+
+    digest = Digest::SHA256.file(a_gem).hexdigest
+    address = digest[0, 8]
+    dir = File.dirname(a_gem)
+    filename = File.join(dir, "a-2-#{address}.gem")
+    FileUtils.cp a_gem, filename
+    installer = Gem::Installer.at filename, install_dir: @gemhome, force: true
+    # deliberately memoize the directory before installation, to prove the installation recalculates
+    installer.gem_dir
+    spec = installer.install
+
+    assert_equal address, spec.content_address
+    assert_equal "a-2-#{address}", spec.full_name
+    assert_path_exist File.join(@gemhome, "gems", "a-2-#{address}")
+    assert_path_exist File.join(@gemhome, "specifications", "a-2-#{address}.gemspec")
+  end
+
+  def test_install_raises_for_mismatched_content_address
+    _, a_gem = util_gem "a", 2
+    dir = File.dirname(a_gem)
+    filename = File.join(dir, "a-2-deadbeef.gem")
+    FileUtils.cp a_gem, filename
+    installer = Gem::Installer.at filename, install_dir: @gemhome, force: true
+
+    e = assert_raise Gem::InstallError do
+      installer.install
+    end
+
+    assert_match(/content address mismatch/, e.message)
+  end
+
+  def test_non_content_addressed_gems_install_as_expected
+    _, a_gem = util_gem "a", 2
+    installer = Gem::Installer.at a_gem, install_dir: @gemhome, force: true
+    spec = installer.install
+
+    assert_nil spec.content_address
+    assert_equal "a-2", spec.full_name
+    assert_path_exist File.join(@gemhome, "gems", "a-2")
+    assert_path_exist File.join(@gemhome, "specifications", "a-2.gemspec")
+  end
+
+  def test_require_works_after_content_addressed_install
+    source_spec, a_gem = util_gem "a", 2 do |spec|
+      spec.files = ["lib/ca_activation_test.rb"]
+    end
+    FileUtils.rm_rf source_spec.gem_dir
+
+    digest = Digest::SHA256.file(a_gem).hexdigest
+    address = digest[0, 8]
+    dir = File.dirname(a_gem)
+    filename = File.join(dir, "a-2-#{address}.gem")
+    FileUtils.cp a_gem, filename
+
+    installer = Gem::Installer.at filename, install_dir: @gemhome, force: true
+    installer.install
+
+    Gem::Specification.reset
+
+    assert require "ca_activation_test"
+  end
+
+  def test_reinstalling_content_addressed_gem_is_idempotent
+    source_spec, a_gem = util_gem "a", 2
+    FileUtils.rm_rf source_spec.gem_dir
+
+    digest = Digest::SHA256.file(a_gem).hexdigest
+    address = digest[0, 8]
+    dir = File.dirname(a_gem)
+    filename = File.join(dir, "a-2-#{address}.gem")
+    FileUtils.cp a_gem, filename
+    installer = Gem::Installer.at filename, install_dir: @gemhome, force: true
+    installer.install
+
+    installer2 = Gem::Installer.at filename, install_dir: @gemhome, force: true
+    spec2 = installer2.install
+
+    assert_equal "a-2-#{address}", spec2.full_name
+    assert_path_exist File.join(@gemhome, "gems", "a-2-#{address}")
+    assert_path_exist File.join(@gemhome, "specifications", "a-2-#{address}.gemspec")
+    assert_equal 1, Dir[File.join(@gemhome, "gems", "a-2*")].size
+    assert_equal 1, Dir[File.join(@gemhome, "specifications", "a-2*.gemspec")].size
   end
 
   def test_install

--- a/test/rubygems/test_gem_installer.rb
+++ b/test/rubygems/test_gem_installer.rb
@@ -1032,7 +1032,10 @@ class TestGemInstaller < Gem::InstallerTestCase
   end
 
   def test_install_assigns_content_address_from_filename
-    _, a_gem = util_gem "a", 2
+    _, a_gem = util_gem("a", 2) do |spec|
+      spec.required_ruby_version = ">= 3.0"
+      spec.platform = "x86_64-linux"
+    end
 
     digest = Digest::SHA256.file(a_gem).hexdigest
     address = digest[0, 8]
@@ -1051,7 +1054,10 @@ class TestGemInstaller < Gem::InstallerTestCase
   end
 
   def test_install_raises_for_mismatched_content_address
-    _, a_gem = util_gem "a", 2
+    _, a_gem = util_gem("a", 2) do |spec|
+      spec.required_ruby_version = ">= 3.0"
+      spec.platform = "x86_64-linux"
+    end
     dir = File.dirname(a_gem)
     filename = File.join(dir, "a-2-deadbeef.gem")
     FileUtils.cp a_gem, filename
@@ -1075,9 +1081,66 @@ class TestGemInstaller < Gem::InstallerTestCase
     assert_path_exist File.join(@gemhome, "specifications", "a-2.gemspec")
   end
 
+  def test_numeric_version_not_treated_as_content_address
+    _, a_gem = util_gem "a", "20240101"
+    installer = Gem::Installer.at a_gem, install_dir: @gemhome, force: true
+    spec = installer.install
+
+    assert_nil spec.content_address
+    assert_equal "a-20240101", spec.full_name
+    assert_path_exist File.join(@gemhome, "gems", "a-20240101")
+    assert_path_exist File.join(@gemhome, "specifications", "a-20240101.gemspec")
+  end
+
+  def test_content_address_not_set_without_required_ruby_version_and_platform
+    _, a_gem = util_gem "a", 2
+    digest = Digest::SHA256.file(a_gem).hexdigest
+    address = digest[0, 8]
+    dir = File.dirname(a_gem)
+    filename = File.join(dir, "a-2-#{address}.gem")
+    FileUtils.cp a_gem, filename
+    installer = Gem::Installer.at filename, install_dir: @gemhome, force: true
+    spec = installer.install
+
+    assert_nil spec.content_address
+    assert_equal "a-2", spec.full_name
+  end
+
+  def test_content_address_not_set_with_only_required_ruby_version
+    _, a_gem = util_gem("a", 2) do |spec|
+      spec.required_ruby_version = ">= 3.0"
+    end
+    digest = Digest::SHA256.file(a_gem).hexdigest
+    address = digest[0, 8]
+    dir = File.dirname(a_gem)
+    filename = File.join(dir, "a-2-#{address}.gem")
+    FileUtils.cp a_gem, filename
+    installer = Gem::Installer.at filename, install_dir: @gemhome, force: true
+    spec = installer.install
+
+    assert_nil spec.content_address
+  end
+
+  def test_content_address_not_set_with_only_platform
+    _, a_gem = util_gem("a", 2) do |spec|
+      spec.platform = "x86_64-linux"
+    end
+    digest = Digest::SHA256.file(a_gem).hexdigest
+    address = digest[0, 8]
+    dir = File.dirname(a_gem)
+    filename = File.join(dir, "a-2-#{address}.gem")
+    FileUtils.cp a_gem, filename
+    installer = Gem::Installer.at filename, install_dir: @gemhome, force: true
+    spec = installer.install
+
+    assert_nil spec.content_address
+  end
+
   def test_require_works_after_content_addressed_install
-    source_spec, a_gem = util_gem "a", 2 do |spec|
+    source_spec, a_gem = util_gem("a", 2) do |spec|
       spec.files = ["lib/ca_activation_test.rb"]
+      spec.required_ruby_version = ">= 3.0"
+      spec.platform = "x86_64-linux"
     end
     FileUtils.rm_rf source_spec.gem_dir
 
@@ -1096,7 +1159,10 @@ class TestGemInstaller < Gem::InstallerTestCase
   end
 
   def test_reinstalling_content_addressed_gem_is_idempotent
-    source_spec, a_gem = util_gem "a", 2
+    source_spec, a_gem = util_gem("a", 2) do |spec|
+      spec.required_ruby_version = ">= 3.0"
+      spec.platform = "x86_64-linux"
+    end
     FileUtils.rm_rf source_spec.gem_dir
 
     digest = Digest::SHA256.file(a_gem).hexdigest

--- a/test/rubygems/test_gem_specification.rb
+++ b/test/rubygems/test_gem_specification.rb
@@ -1963,17 +1963,11 @@ dependencies: []
 
   def test_content_addressable_full_name
     @a1 = Gem::Specification.new "a", 1
+    @a1.required_ruby_version = ">= 3.0"
     @a1.platform = "x86_64-linux"
     @a1.content_address = "abcdef12"
     assert_equal "a-1-abcdef12", @a1.full_name
     assert_equal "x86_64-linux", @a1.platform.to_s
-  end
-
-  def test_content_address_predicate
-    assert Gem::BasicSpecification.content_address?("abcdef12")
-    refute Gem::BasicSpecification.content_address?("x86_64-linux")
-    refute Gem::BasicSpecification.content_address?(nil)
-    refute Gem::BasicSpecification.content_address?("abc")
   end
 
   def test_full_name_windows
@@ -2004,10 +1998,12 @@ dependencies: []
 
   def test_content_addressable_specs_are_distinct
     first = Gem::Specification.new "a", 1
+    first.required_ruby_version = ">= 3.0"
     first.platform = "arm64-darwin"
     first.content_address = "abcdef12"
 
     second = Gem::Specification.new "a", 1
+    second.required_ruby_version = ">= 3.0"
     second.platform = "arm64-darwin"
     second.content_address = "12345678"
 
@@ -2410,6 +2406,7 @@ end
 
   def test_to_ruby_content_addressable
     spec = Gem::Specification.new "a", 1
+    spec.required_ruby_version = ">= 3.0"
     spec.platform = "x86_64-linux"
     spec.content_address = "abcdef12"
     spec.extensions = ["ext/a/extconf.rb"]

--- a/test/rubygems/test_gem_specification.rb
+++ b/test/rubygems/test_gem_specification.rb
@@ -1961,6 +1961,21 @@ dependencies: []
     assert_equal "a-1-x86-darwin-8", @a1.full_name
   end
 
+  def test_content_addressable_full_name
+    @a1 = Gem::Specification.new "a", 1
+    @a1.platform = "x86_64-linux"
+    @a1.content_address = "abcdef12"
+    assert_equal "a-1-abcdef12", @a1.full_name
+    assert_equal "x86_64-linux", @a1.platform.to_s
+  end
+
+  def test_content_address_predicate
+    assert Gem::BasicSpecification.content_address?("abcdef12")
+    refute Gem::BasicSpecification.content_address?("x86_64-linux")
+    refute Gem::BasicSpecification.content_address?(nil)
+    refute Gem::BasicSpecification.content_address?("abc")
+  end
+
   def test_full_name_windows
     test_cases = {
       "i386-mswin32" => "a-1-x86-mswin32-60",
@@ -1985,6 +2000,19 @@ dependencies: []
     assert_equal @a1.hash, @a1.hash
     assert_equal @a1.hash, @a1.dup.hash
     refute_equal @a1.hash, @a2.hash
+  end
+
+  def test_content_addressable_specs_are_distinct
+    first = Gem::Specification.new "a", 1
+    first.platform = "arm64-darwin"
+    first.content_address = "abcdef12"
+
+    second = Gem::Specification.new "a", 1
+    second.platform = "arm64-darwin"
+    second.content_address = "12345678"
+
+    refute_equal first, second
+    assert_equal 2, [first, second].uniq.size
   end
 
   def test_installed_by_version
@@ -2378,6 +2406,30 @@ end
     same_spec = eval ruby_code
 
     assert_equal @a2, same_spec
+  end
+
+  def test_to_ruby_content_addressable
+    spec = Gem::Specification.new "a", 1
+    spec.platform = "x86_64-linux"
+    spec.content_address = "abcdef12"
+    spec.extensions = ["ext/a/extconf.rb"]
+
+    ruby_code = spec.to_ruby
+
+    expected_stub = <<~STUB.chomp
+      # stub: a 1 abcdef12 lib
+      # stub-target: platform=x86_64-linux
+      # stub: ext/a/extconf.rb
+    STUB
+
+    assert_includes ruby_code, expected_stub
+    assert_includes ruby_code, "if s.respond_to? :content_address="
+
+    same_spec = eval ruby_code
+
+    assert_equal "abcdef12", same_spec.content_address
+    assert_equal "x86_64-linux", same_spec.platform.to_s
+    assert_equal "a-1-abcdef12", same_spec.full_name
   end
 
   def test_to_ruby_with_rsa_key

--- a/test/rubygems/test_gem_stub_specification.rb
+++ b/test/rubygems/test_gem_stub_specification.rb
@@ -23,6 +23,26 @@ class TestStubSpecification < Gem::TestCase
     assert @foo.stubbed?
   end
 
+  def test_initialize_with_target
+    stub = stub_with_target
+
+    assert_equal "stub_with_target", stub.name
+    assert_equal v(2), stub.version
+    assert_equal Gem::Platform.new("x86_64-linux"), stub.platform
+    assert_equal [stub.extension_dir, "lib"], stub.require_paths
+    assert_equal %w[ext/stub_with_target/extconf.rb], stub.extensions
+    assert_equal "ab12345678", stub.content_address
+    assert_equal "stub_with_target-2-ab12345678", stub.full_name
+  end
+
+  def test_content_addressable_stubs_are_distinct
+    first = stub_with_target "ab12345678"
+    second = stub_with_target "cd12345678"
+
+    refute_equal first, second
+    assert_equal 2, [first, second].uniq.size
+  end
+
   def test_initialize_extension
     stub = stub_with_extension
 
@@ -278,6 +298,31 @@ class TestStubSpecification < Gem::TestCase
         Gem::Specification.new do |s|
           s.name = 'stub_v'
           s.version = ""
+        end
+      STUB
+
+      io.flush
+
+      stub = Gem::StubSpecification.gemspec_stub io.path, @gemhome, File.join(@gemhome, "gems")
+
+      yield stub if block_given?
+
+      return stub
+    end
+  end
+
+  def stub_with_target(content_address = "ab12345678")
+    spec = File.join @gemhome, "specifications", "stub_with_target-#{content_address}.gemspec"
+    File.open spec, "w" do |io|
+      io.write <<~STUB
+        # -*- encoding: utf-8 -*-
+        # stub: stub_with_target 2 #{content_address} lib
+        # stub-target: platform=x86_64-linux
+        # stub: ext/stub_with_target/extconf.rb
+
+        Gem::Specification.new do |s|
+          s.name = 'stub_with_target'
+          s.version = Gem::Version.new '2'
         end
       STUB
 


### PR DESCRIPTION
### TL;DR
Adjusts the local install process to support content addressable gem naming.

Addresses Issue: https://github.com/ruby/rubygems/issues/9730

### Description

This PR updates components of the local gem install flow to allow the option that gems may be content addressed.  `gem install ./my_gem-1.0.0-ab12345678.gem` reaches `Gem::Installer`, which opens the archive and reads its full specification. At the start of install, the new code now recognises the content address filename suffix, verifies it against the archive’s actual derived digest, and stores it as spec.content_address. The `BasicSpecification#full_name` change then produces `my_gem-1.0.0-ab12345678`, so the existing installer goes on to naturally use SHA-based directory and gemspec names. When it writes the installed gemspec, the `Specification#to_ruby` changes preserve both identities: the stub suffix contains the SHA, while stub-target contains the real platform. Later, when RubyGems searches installed gems for require, `StubSpecification` reads those lightweight comments; the StubLine changes reconstruct the SHA-based `full_name` while exposing the real platform for compatibility checks. 
  
**Changes breakdown:**
- `Gem::BasicSpecification#full_name` now returns a content addressed name (name-version-content_address) if the `content_address` value is a present attribute on the specification. 
- `Gem::StubSpecification#data` now optionally passes a `target` hash (`{platform => 'x86_64-linux'}`) to `Stubline.new` when it parses the value from the specfiles. The platform value in this target hash is used to calculate and assign the `@platform` attribute in `initialize` in content addressable cases. In all cases, we scan the third position in the stub line, see if it matches a CA regex, and if so, set it as our `@content_address` attribute.
- `Gem::Installer` calls `assign_content_address` when it initialises, and derives the content address hash from the file name. It also checks that this matches with a recalculated SHA digest based on the file contents. If we are able to derive a matching content_address from the file name, we assign it to `spec`. 

### Testing
Tests added to `test_gem_installer`, `test_gem_specification` and `test_gem_stub_specification`. 

### Tophat
  1. Build a gem and rename it to `<name>-<version>-<first-10-chars-of-sha256>.gem`.
  2. Install it locally with `gem install ./<file>`.
  3. Confirm the installed gem directory and gemspec include the SHA.
  4. Confirm `require` works.
  5. Reinstall it and confirm no duplicate installation is created.
  6. Rename it with an incorrect SHA and confirm installation fails.