### PR TITLE
[Content Addressable] Support Content Addressable Gems in Remote Install Process

### DIFF
--- a/lib/rubygems/resolver.rb
+++ b/lib/rubygems/resolver.rb
@@ -396,10 +396,11 @@ class Gem::Resolver
       next installed.first if installed.length == 1
       candidates = installed if installed.any?
 
-      # Among remaining candidates, prefer the most specific platform, then the
-      # earlier-supplied source.
+      # Among remaining candidates, prefer the most specific platform, then a
+      # content-addressed candidate, then the earlier-supplied source.
       candidates.min_by do |s|
         [Gem::Platform.platform_specificity_match(s.platform, Gem::Platform.local),
+         Gem::ContentAddress.match?(s.content_address) ? 0 : 1,
          source_rank[s.source]]
       end
     end

--- a/lib/rubygems/resolver/api_set.rb
+++ b/lib/rubygems/resolver/api_set.rb
@@ -108,12 +108,12 @@ class Gem::Resolver::APISet < Gem::Resolver::Set
       []
     end
 
-    infos.each do |_, number, platform, dependencies, requirements|
-      platform ||= "ruby"
+    infos.each do |_, number, suffix, dependencies, requirements|
+      suffix ||= "ruby"
       dependencies = dependencies.map {|dep_name, reqs| [dep_name, reqs.join(", ")] }
       requirements = requirements.map {|req_name, reqs| [req_name.to_sym, reqs] }.to_h
 
-      @data[name] << { name: name, number: number, platform: platform, dependencies: dependencies, requirements: requirements }
+      @data[name] << { name: name, number: number, suffix: suffix, dependencies: dependencies, requirements: requirements }
     end
 
     @data[name]

--- a/lib/rubygems/resolver/api_specification.rb
+++ b/lib/rubygems/resolver/api_specification.rb
@@ -31,8 +31,7 @@ class Gem::Resolver::APISpecification < Gem::Resolver::Specification
     @set = set
     @name = api_data[:name]
     @version = Gem::Version.new(api_data[:number]).freeze
-    @platform = Gem::Platform.new(api_data[:platform]).freeze
-    @original_platform = api_data[:platform].freeze
+    assign_platform(api_data)
     @dependencies = api_data[:dependencies].map do |name, ver|
       Gem::Dependency.new(name, ver.split(/\s*,\s*/)).freeze
     end.freeze
@@ -46,15 +45,17 @@ class Gem::Resolver::APISpecification < Gem::Resolver::Specification
       @set          == other.set &&
       @name         == other.name &&
       @version      == other.version &&
-      @platform     == other.platform
+      @platform     == other.platform &&
+      @content_address == other.content_address
   end
 
   def hash
-    @set.hash ^ @name.hash ^ @version.hash ^ @platform.hash
+    @set.hash ^ @name.hash ^ @version.hash ^ @platform.hash ^ @content_address.hash
   end
 
   def fetch_development_dependencies # :nodoc:
-    spec = source.fetch_spec Gem::NameTuple.new @name, @version, @platform
+    suffix = @content_address || @platform
+    spec = source.fetch_spec Gem::NameTuple.new @name, @version, suffix
 
     @dependencies = spec.dependencies
   end
@@ -99,6 +100,7 @@ class Gem::Resolver::APISpecification < Gem::Resolver::Specification
       s.original_platform = @original_platform
       s.required_ruby_version = @required_ruby_version
       s.required_rubygems_version = @required_rubygems_version
+      s.content_address = @content_address
 
       @dependencies.each do |dependency|
         s.add_runtime_dependency dependency.name, *dependency.requirement.as_list
@@ -111,6 +113,30 @@ class Gem::Resolver::APISpecification < Gem::Resolver::Specification
   end
 
   private
+
+  def assign_platform(api_data)
+    suffix = api_data[:suffix]
+    required_platform = required_platform_from(api_data.dig(:requirements, :platform))
+
+    if Gem::ContentAddress.match?(suffix) && required_platform
+      @content_address = suffix.freeze
+      @platform = required_platform.freeze
+      @original_platform = required_platform.to_s.freeze
+    else
+      @content_address = nil
+      @platform = Gem::Platform.new(suffix).freeze
+      @original_platform = suffix.freeze
+    end
+  end
+
+  def required_platform_from(requirement)
+    return unless requirement
+
+    op, platform = requirement.last.split(" ", 2)
+    return unless op == "=" && platform
+
+    Gem::Platform.new(platform)
+  end
 
   def parse_created_at(value)
     value = value.first if value.is_a?(Array)

--- a/lib/rubygems/resolver/spec_specification.rb
+++ b/lib/rubygems/resolver/spec_specification.rb
@@ -23,6 +23,10 @@ class Gem::Resolver::SpecSpecification < Gem::Resolver::Specification
     spec.dependencies
   end
 
+  def content_address # :nodoc:
+    spec.content_address
+  end
+
   ##
   # The required_ruby_version constraint for this specification
 

--- a/lib/rubygems/resolver/specification.rb
+++ b/lib/rubygems/resolver/specification.rb
@@ -61,6 +61,11 @@ class Gem::Resolver::Specification
   attr_reader :created_at
 
   ##
+  # The content address of this specification.
+
+  attr_reader :content_address
+
+  ##
   # Sets default instance variables for the specification.
 
   def initialize
@@ -73,6 +78,7 @@ class Gem::Resolver::Specification
     @version      = nil
     @required_ruby_version = Gem::Requirement.default
     @required_rubygems_version = Gem::Requirement.default
+    @content_address = nil
   end
 
   ##

--- a/test/rubygems/test_gem_installer.rb
+++ b/test/rubygems/test_gem_installer.rb
@@ -1092,12 +1092,38 @@ class TestGemInstaller < Gem::InstallerTestCase
     assert_path_exist File.join(@gemhome, "specifications", "a-20240101.gemspec")
   end
 
+  def test_normal_gem_with_hex_suffix_is_not_content_addressed
+    _, a_gem = util_gem "a", 2 do |spec|
+      spec.platform = Gem::Platform.new("x86-linux-deadbeef")
+    end
+    installer = Gem::Installer.at a_gem, install_dir: @gemhome, force: true
+    spec = installer.install
+
+    assert_nil spec.content_address
+    assert_equal "a-2-x86-linux-deadbeef", spec.full_name
+  end
+
   def test_content_address_not_set_without_required_ruby_version_and_platform
     _, a_gem = util_gem "a", 2
     digest = Digest::SHA256.file(a_gem).hexdigest
     address = digest[0, 8]
     dir = File.dirname(a_gem)
     filename = File.join(dir, "a-2-#{address}.gem")
+    FileUtils.cp a_gem, filename
+    installer = Gem::Installer.at filename, install_dir: @gemhome, force: true
+    spec = installer.install
+
+    assert_nil spec.content_address
+    assert_equal "a-2", spec.full_name
+  end
+
+  def test_hex_suffix_without_matching_spec_prefix_is_not_content_addressed
+    _, a_gem = util_gem "a", 2
+
+    digest = Digest::SHA256.file(a_gem).hexdigest
+    address = digest[0, 8]
+    dir = File.dirname(a_gem)
+    filename = File.join(dir, "wrong_name-2-#{address}.gem")
     FileUtils.cp a_gem, filename
     installer = Gem::Installer.at filename, install_dir: @gemhome, force: true
     spec = installer.install

--- a/test/rubygems/test_gem_remote_fetcher.rb
+++ b/test/rubygems/test_gem_remote_fetcher.rb
@@ -125,6 +125,29 @@ class TestGemRemoteFetcher < Gem::TestCase
     assert File.exist?(a1_cache_gem)
   end
 
+  def test_download_and_install_content_addressed_gem
+    require "digest"
+
+    ca_spec, ca_gem = util_gem "a", "1" do |s|
+      s.required_ruby_version = ">= 3.0"
+      s.platform = "x86_64-linux"
+    end
+
+    address = Digest::SHA256.file(ca_gem).hexdigest[0, 10]
+    ca_spec.content_address = address
+    gem_data = File.binread ca_gem
+    gem_url = "http://gems.example.com/gems/a-1-#{address}.gem"
+    fetcher = fake_fetcher(gem_url, gem_data)
+
+    gem_path = fetcher.download(ca_spec, "http://gems.example.com")
+    installed_spec = Gem::Installer.at(gem_path, install_dir: @gemhome, force: true).install
+
+    assert_equal gem_url, fetcher.paths.last
+    assert_equal address, installed_spec.content_address
+    assert_equal "a-1-#{address}", installed_spec.full_name
+    assert_path_exist installed_spec.full_gem_path
+  end
+
   def test_download_with_auth
     a1_data = File.open @a1_gem, "rb", &:read
     a1_url = "http://user:password@gems.example.com/gems/a-1.gem"

--- a/test/rubygems/test_gem_resolver.rb
+++ b/test/rubygems/test_gem_resolver.rb
@@ -322,6 +322,67 @@ class TestGemResolver < Gem::TestCase
     assert_resolves_to [a2_p1.spec], res
   end
 
+  def test_prefers_content_addressed_gem_for_same_platform
+    ca_spec = util_spec "a", "1"
+    spec = util_spec "a", "1"
+
+    ca_spec.platform = Gem::Platform.local
+    ca_spec.content_address = "abc1234567"
+    spec.platform = Gem::Platform.local
+
+    s = set(spec, ca_spec)
+    dependency = make_dep "a"
+    resolver = Gem::Resolver.new([dependency], s)
+    assert_resolves_to [ca_spec], resolver
+  end
+
+  def test_falls_back_to_fat_when_content_addressed_gem_requires_other_rubygems_version
+    ca_spec = util_spec "a", "1"
+    fat_spec = util_spec "a", "1"
+
+    ca_spec.platform = Gem::Platform.local
+    ca_spec.content_address = "abc1234567"
+    ca_spec.required_rubygems_version = ">= 999"
+    fat_spec.platform = Gem::Platform.local
+
+    s = set(fat_spec, ca_spec)
+    dependency = make_dep "a"
+    resolver = Gem::Resolver.new([dependency], s)
+    assert_resolves_to [fat_spec], resolver
+  end
+
+  def test_falls_back_to_source_when_content_addressed_gem_requires_other_ruby
+    ca_spec = util_spec "a", "1"
+    source_spec = util_spec "a", "1"
+
+    ca_spec.platform = Gem::Platform.local
+    ca_spec.content_address = "abc1234567"
+    ca_spec.required_ruby_version = ">= 999"
+    source_spec.platform = Gem::Platform::RUBY
+
+    s = set(source_spec, ca_spec)
+    dependency = make_dep "a"
+    resolver = Gem::Resolver.new([dependency], s)
+    assert_resolves_to [source_spec], resolver
+  end
+
+  def test_falls_back_to_fat_before_source_when_content_addressed_gem_requires_other_ruby
+    ca_spec = util_spec "a", "1"
+    fat_spec = util_spec "a", "1"
+    source_spec = util_spec "a", "1"
+
+    ca_spec.platform = Gem::Platform.local
+    ca_spec.content_address = "abc1234567"
+    ca_spec.required_ruby_version = ">= 999"
+    fat_spec.platform = Gem::Platform.local
+    source_spec.platform = Gem::Platform::RUBY
+
+    s = set(source_spec, fat_spec, ca_spec)
+    dependency = make_dep "a"
+    resolver = Gem::Resolver.new([dependency], s)
+    assert_resolves_to [fat_spec], resolver
+  end
+
   def test_does_not_pick_musl_variants_on_non_musl_linux
     util_set_arch "aarch64-linux" do
       is = Gem::Resolver::IndexSpecification

--- a/test/rubygems/test_gem_resolver_api_set.rb
+++ b/test/rubygems/test_gem_resolver_api_set.rb
@@ -38,7 +38,7 @@ class TestGemResolverAPISet < Gem::TestCase
     data = [
       { name: "a",
         number: "1",
-        platform: "ruby",
+        suffix: "ruby",
         dependencies: [] },
     ]
 
@@ -55,17 +55,31 @@ class TestGemResolverAPISet < Gem::TestCase
     assert_equal expected, set.find_all(a_dep)
   end
 
+  def test_find_all_content_addressed
+    spec_fetcher
+
+    @fetcher.data["#{@dep_uri}a"] = util_compact_index_response("---\n1-ab12345678 |platform:= #{Gem::Platform.local}\n")
+
+    set = Gem::Resolver::APISet.new @dep_uri
+    a_dep = Gem::Resolver::DependencyRequest.new dep("a"), nil
+    spec = set.find_all(a_dep).first
+
+    assert_equal "ab12345678", spec.content_address
+    assert_equal Gem::Platform.local, spec.platform
+    assert Gem::ContentAddress.match?(spec.content_address)
+  end
+
   def test_find_all_prereleases
     spec_fetcher
 
     data = [
       { name: "a",
         number: "1",
-        platform: "ruby",
+        suffix: "ruby",
         dependencies: [] },
       { name: "a",
         number: "2.a",
-        platform: "ruby",
+        suffix: "ruby",
         dependencies: [] },
     ]
 
@@ -90,7 +104,7 @@ class TestGemResolverAPISet < Gem::TestCase
     data = [
       { name: "a",
         number: "1",
-        platform: "ruby",
+        suffix: "ruby",
         dependencies: [] },
     ]
 

--- a/test/rubygems/test_gem_resolver_api_specification.rb
+++ b/test/rubygems/test_gem_resolver_api_specification.rb
@@ -8,7 +8,7 @@ class TestGemResolverAPISpecification < Gem::TestCase
     data = {
       name: "rails",
       number: "3.0.3",
-      platform: Gem::Platform.local.to_s,
+      suffix: Gem::Platform.local.to_s,
       dependencies: [
         ["bundler",  "~> 1.0"],
         ["railties", "= 3.0.3"],
@@ -30,12 +30,64 @@ class TestGemResolverAPISpecification < Gem::TestCase
     assert_nil spec.created_at
   end
 
+  def test_initialize_content_address
+    set = Gem::Resolver::APISet.new
+    data = {
+      name: "rails",
+      number: "3.0.3",
+      suffix: "abc1234567",
+      dependencies: [],
+      requirements: { platform: ["= #{Gem::Platform.local}"] },
+    }
+
+    spec = Gem::Resolver::APISpecification.new set, data
+
+    assert_equal "abc1234567", spec.content_address
+    assert_equal Gem::Platform.local, spec.platform
+    assert Gem::ContentAddress.match?(spec.content_address)
+    assert_equal "abc1234567", spec.spec.content_address
+  end
+
+  def test_initialize_does_not_treat_non_content_address_suffix_as_content_addressed
+    set = Gem::Resolver::APISet.new
+    data = {
+      name: "rails",
+      number: "3.0.3",
+      suffix: Gem::Platform.local.to_s,
+      dependencies: [],
+      requirements: { platform: ["= #{Gem::Platform.local}"] },
+    }
+
+    spec = Gem::Resolver::APISpecification.new set, data
+
+    assert_nil spec.content_address
+    refute Gem::ContentAddress.match?(spec.content_address)
+    assert_equal Gem::Platform.local, spec.platform
+  end
+
+  def test_content_addressed_specs_with_different_addresses_are_distinct
+    set = Gem::Resolver::APISet.new
+    data = {
+      name: "rails",
+      number: "3.0.3",
+      suffix: "abc1234567",
+      dependencies: [],
+      requirements: { platform: ["= #{Gem::Platform.local}"] },
+    }
+
+    first = Gem::Resolver::APISpecification.new set, data
+    second = Gem::Resolver::APISpecification.new set, data.merge(suffix: "def1234567")
+
+    refute_equal first, second
+    refute_equal first.hash, second.hash
+  end
+
   def test_initialize_created_at
     set = Gem::Resolver::APISet.new
     data = {
       name: "rails",
       number: "3.0.3",
-      platform: "ruby",
+      suffix: "ruby",
       dependencies: [],
       requirements: { created_at: ["2026-06-05T10:30:45Z"] },
     }
@@ -50,7 +102,7 @@ class TestGemResolverAPISpecification < Gem::TestCase
     data = {
       name: "rails",
       number: "3.0.3",
-      platform: "ruby",
+      suffix: "ruby",
       dependencies: [],
       requirements: { created_at: ["not a timestamp"] },
     }
@@ -65,7 +117,7 @@ class TestGemResolverAPISpecification < Gem::TestCase
     data = {
       name: "rails",
       number: "3.0.3",
-      platform: "ruby",
+      suffix: "ruby",
       dependencies: [],
       requirements: { created_at: ["2026"] },
     }
@@ -93,7 +145,7 @@ class TestGemResolverAPISpecification < Gem::TestCase
     data = {
       name: "rails",
       number: "3.0.3",
-      platform: "ruby",
+      suffix: "ruby",
       dependencies: [
         ["bundler",  "~> 1.0"],
         ["railties", "= 3.0.3"],
@@ -115,12 +167,42 @@ class TestGemResolverAPISpecification < Gem::TestCase
     assert_equal expected, spec.dependencies
   end
 
+  def test_fetch_development_dependencies_for_content_addressed_spec
+    fetched_tuple = nil
+    fetched_spec = util_spec "rails", "3.0.3" do |s|
+      s.add_development_dependency "a", "= 1"
+    end
+
+    source = Object.new
+    source.define_singleton_method(:fetch_spec) do |tuple|
+      fetched_tuple = tuple
+      fetched_spec
+    end
+
+    set = Gem::Resolver::APISet.new
+    set.instance_variable_set :@source, source
+    data = {
+      name: "rails",
+      number: "3.0.3",
+      suffix: "abc1234567",
+      dependencies: [],
+      requirements: { platform: ["= #{Gem::Platform.local}"] },
+    }
+
+    spec = Gem::Resolver::APISpecification.new set, data
+
+    spec.fetch_development_dependencies
+
+    assert_equal "rails-3.0.3-abc1234567.gemspec", fetched_tuple.spec_name
+    assert_equal [Gem::Dependency.new("a", "= 1", :development)], spec.dependencies
+  end
+
   def test_installable_platform_eh
     set = Gem::Resolver::APISet.new
     data = {
       name: "a",
       number: "1",
-      platform: "ruby",
+      suffix: "ruby",
       dependencies: [],
     }
 
@@ -131,7 +213,7 @@ class TestGemResolverAPISpecification < Gem::TestCase
     data = {
       name: "b",
       number: "1",
-      platform: "cpu-other_platform-1",
+      suffix: "cpu-other_platform-1",
       dependencies: [],
     }
 
@@ -142,7 +224,7 @@ class TestGemResolverAPISpecification < Gem::TestCase
     data = {
       name: "c",
       number: "1",
-      platform: Gem::Platform.local.to_s,
+      suffix: Gem::Platform.local.to_s,
       dependencies: [],
     }
 
@@ -156,7 +238,7 @@ class TestGemResolverAPISpecification < Gem::TestCase
     data = {
       name: "a",
       number: "1",
-      platform: "ruby",
+      suffix: "ruby",
       dependencies: [],
     }
 
@@ -175,7 +257,7 @@ class TestGemResolverAPISpecification < Gem::TestCase
     data = {
       name: "a",
       number: "1",
-      platform: "ruby",
+      suffix: "ruby",
       dependencies: [],
     }
 
@@ -199,7 +281,7 @@ class TestGemResolverAPISpecification < Gem::TestCase
     data = {
       name: "j",
       number: "1",
-      platform: "jruby",
+      suffix: "jruby",
       dependencies: [],
     }
 


### PR DESCRIPTION
## TL;DR

  Adds support for resolving, downloading, and installing content-addressed (“skinny”) gems from a remote source.

  ## Description
  
  Addresses: https://github.com/ruby/rubygems/issues/9731

[Note - at the moment we also have the commit from the local install work on this branch as well as the first commit. That will be removed and this PR will be rebased once the local install work is merged into the feature branch.]

  Compact-index entries for skinny gems use the content address as the version suffix and provide the real platform through the `platform:` requirement.

  This change:

  - Separates the content address from the gem’s real platform.
  - Carries the content address through the resolver into the full specification.
  - Prefers a compatible skinny gem over fat and source variants.
  - Falls back to fat or source gems when the skinny gem is incompatible.
  - Downloads gems and development gemspecs using their content-addressed filenames.
  - Preserves distinct resolver candidates when their content addresses differ.

  This PR builds on the local content-addressed installation work.

  ## Testing

```
  ruby --disable-gems -Ilib:test \
    test/rubygems/test_gem_resolver_api_set.rb \
    test/rubygems/test_gem_resolver_api_specification.rb \
    test/rubygems/test_gem_resolver.rb \
    test/rubygems/test_gem_remote_fetcher.rb
```

  The tests cover:

  - Parsing content-addressed compact-index entries.
  - Selecting compatible skinny gems.
  - Falling back to fat or source gems.
  - Respecting Ruby and RubyGems requirements.
  - Downloading SHA-named gem archives.
  - Fetching SHA-named gemspecs for development dependencies.

  ## Top hatting

  1. Configure a gem server containing compatible skinny, fat, and source variants.
  2. Install the gem using this RubyGems checkout:

```
     ruby --disable-gems -Ilib exe/gem install GEM_NAME \
       --source SERVER_URL \
       --install-dir "$(mktemp -d)"
```

  3. Confirm the compatible SHA-named gem was downloaded and installed.
  4. Confirm the installed specification reports the real platform.
  5. Confirm the gem can be required.
  6. Repeat with no compatible skinny variant and confirm installation falls back to the fat or source gem.
  
**Tested the following locally, behaving as expected:** 
- Remote compact-index lookup.
- CA gem selection by Ruby ABI and platform.
- SHA-named gem download and installation.
- Correct installed SHA directory, gemspec, and cache names.
- Correct real platform and content address.
- Successful activation with require.
- Idempotent CA re-installation.
- Normal non-CA platform gem download, installation, and activation.