### PR TITLE
Allow gem push to select content-addressable gems by platform and Ruby ABI

### DIFF
--- a/lib/rubygems/commands/push_command.rb
+++ b/lib/rubygems/commands/push_command.rb
@@ -45,6 +45,18 @@ The push command will use ~/.gem/credentials to authenticate to a server, but yo
       @user_defined_host = true
     end
 
+    add_option("--platform PLATFORM",
+               "Push a gem for a specific platform",
+               "  (e.g. x86_64-darwin-20)") do |value, options|
+      options[:platform] = value
+    end
+
+    add_option("--ruby-abi RUBY_ABI",
+               "Push a gem for a specific Ruby ABI",
+               "  (e.g. 3.4)") do |value, options|
+      options[:ruby_abi] = value
+    end
+
     add_option("--attestation FILE",
                 "Push with sigstore attestations") do |value, options|
       options[:attestations] << value
@@ -54,7 +66,14 @@ The push command will use ~/.gem/credentials to authenticate to a server, but yo
   end
 
   def execute
-    gem_name = get_one_gem_name
+    validate_ruby_abi_option if options[:ruby_abi]
+
+    gem_name = if gem_name_selectors?
+      resolve_gem_name(get_all_gem_names)
+    else
+      get_one_gem_name
+    end
+
     default_gem_server, push_host = get_hosts_for(gem_name)
 
     @host = if @user_defined_host
@@ -90,6 +109,69 @@ The push command will use ~/.gem/credentials to authenticate to a server, but yo
   end
 
   private
+
+  def gem_name_selectors?
+    options[:platform] || options[:ruby_abi]
+  end
+
+  def resolve_gem_name(names)
+    candidates = names.filter_map do |name|
+      [name, Gem::Package.new(name).spec]
+    rescue Gem::Package::FormatError => e
+      alert_warning "Skipping #{name}: #{e.message}"
+      nil
+    end
+
+    matches = candidates.select do |_, spec|
+      platform_matches?(spec) && ruby_matches?(spec)
+    end
+
+    raise Gem::CommandLineError, "No gem matched #{gem_name_selector_description}" if matches.empty?
+    raise Gem::CommandLineError, multiple_matches_message(matches) if matches.length > 1
+
+    matches.first.first
+  end
+
+  def validate_ruby_abi_option
+    return if /\A\d+\.\d+\z/.match?(options[:ruby_abi])
+
+    raise Gem::CommandLineError, "Ruby ABI must be in X.Y format"
+  end
+
+  def multiple_matches_message(matches)
+    message = "Multiple gems matched #{gem_name_selector_description}: #{matches.map(&:first).join(", ")}"
+    suggestion = multiple_matches_suggestion(matches)
+    message += "\n#{suggestion}" if suggestion
+    message
+  end
+
+  def multiple_matches_suggestion(matches)
+    if options[:platform] && !options[:ruby_abi]
+      ruby_abis = matches.filter_map {|_, spec| spec.ruby_abi }.uniq.sort
+      suggestions = []
+      suggestions << "Specify --ruby-abi with one of: #{ruby_abis.join(", ")}" unless ruby_abis.empty?
+      suggestions << "To push a gem without a Ruby ABI, pass the exact filename." if matches.any? {|_, spec| spec.ruby_abi.nil? }
+      suggestions.join("\n") unless suggestions.empty?
+    elsif options[:ruby_abi] && !options[:platform]
+      platforms = matches.map {|_, spec| spec.platform.to_s }.uniq.sort
+      "Specify --platform with one of: #{platforms.join(", ")}" unless platforms.empty?
+    end
+  end
+
+  def gem_name_selector_description
+    selectors = []
+    selectors << "platform #{options[:platform]}" if options[:platform]
+    selectors << "Ruby ABI #{options[:ruby_abi]}" if options[:ruby_abi]
+    selectors.join(" and ")
+  end
+
+  def platform_matches?(spec)
+    !options[:platform] || spec.platform == Gem::Platform.new(options[:platform])
+  end
+
+  def ruby_matches?(spec)
+    !options[:ruby_abi] || spec.ruby_abi == options[:ruby_abi]
+  end
 
   def send_push_request(name, args)
     # Always honor explicit --attestation option

--- a/test/rubygems/helper.rb
+++ b/test/rubygems/helper.rb
@@ -847,7 +847,7 @@ class Gem::TestCase < Test::Unit::TestCase
   # Builds a gem from +spec+ and places it in <tt>File.join @gemhome,
   # 'cache'</tt>.  Automatically creates files based on +spec.files+
 
-  def util_build_gem(spec)
+  def util_build_gem(spec, ruby_abi: nil)
     dir = spec.gem_dir
     FileUtils.mkdir_p dir
 
@@ -861,12 +861,14 @@ class Gem::TestCase < Test::Unit::TestCase
         end
       end
 
+      built_gem_name = nil
       use_ui Gem::MockGemUi.new do
-        Gem::Package.build spec
+        built_gem_name = Gem::Package.build spec, false, false, nil, ruby_abi
       end
 
-      cache = spec.cache_file
+      cache = File.join File.dirname(spec.cache_file), File.basename(built_gem_name)
       FileUtils.mv File.basename(cache), cache
+      cache
     end
   end
 
@@ -984,11 +986,12 @@ class Gem::TestCase < Test::Unit::TestCase
 
   ##
   # Creates a gem with +name+, +version+ and +deps+.  The specification will
-  # be yielded before gem creation for customization.  The gem will be placed
-  # in <tt>File.join @tempdir, 'gems'</tt>.  The specification and .gem file
-  # location are returned.
+  # be yielded before gem creation for customization.  When +ruby_abi+ is set,
+  # the gem is built using a content-addressable file name for that Ruby ABI.
+  # The gem will be placed in <tt>File.join @tempdir, 'gems'</tt>.  The
+  # specification and .gem file location are returned.
 
-  def util_gem(name, version, deps = nil, &block)
+  def util_gem(name, version, deps = nil, ruby_abi: nil, &block)
     if deps
       block = proc do |s|
         deps.keys.each do |n|
@@ -999,11 +1002,11 @@ class Gem::TestCase < Test::Unit::TestCase
 
     spec = quick_gem(name, version, &block)
 
-    util_build_gem spec
+    built_gem_path = util_build_gem spec, ruby_abi: ruby_abi
 
-    cache_file = File.join @tempdir, "gems", "#{spec.original_name}.gem"
+    cache_file = File.join @tempdir, "gems", File.basename(built_gem_path)
     FileUtils.mkdir_p File.dirname cache_file
-    FileUtils.mv spec.cache_file, cache_file
+    FileUtils.mv built_gem_path, cache_file
     FileUtils.rm spec.spec_file
 
     spec.loaded_from = nil

--- a/test/rubygems/test_gem_commands_push_command.rb
+++ b/test/rubygems/test_gem_commands_push_command.rb
@@ -102,6 +102,307 @@ class TestGemCommandsPushCommand < Gem::TestCase
                  @fetcher.last_request["Content-Type"]
   end
 
+  def test_handle_options_platform_and_ruby_abi
+    @cmd.handle_options %w[--platform arm64-darwin --ruby-abi 3.4 demo.gem]
+
+    assert_equal "arm64-darwin", @cmd.options[:platform]
+    assert_equal "3.4", @cmd.options[:ruby_abi]
+    assert_equal ["demo.gem"], @cmd.options[:args]
+  end
+
+  def test_execute_with_platform_selector_selects_matching_gem
+    _, matching_path = util_gem "platform-match", "1.0.0", ruby_abi: "3.4" do |spec|
+      spec.files = ["lib/platform-match.rb"]
+      spec.platform = "arm64-darwin"
+    end
+    _, other_path = util_gem "platform-other", "1.0.0", ruby_abi: "3.4" do |spec|
+      spec.files = ["lib/platform-other.rb"]
+      spec.platform = "x86_64-linux"
+    end
+
+    @response = "Successfully registered gem: platform-match (1.0.0)"
+    @fetcher.data["#{Gem.host}/api/v1/gems"] = HTTPResponseFactory.create(body: @response, code: 200, msg: "OK")
+
+    @cmd.options[:args] = [other_path, matching_path]
+    @cmd.options[:platform] = "arm64-darwin"
+
+    @cmd.execute
+
+    assert_equal Gem::Net::HTTP::Post, @fetcher.last_request.class
+    assert_equal Gem.read_binary(matching_path), @fetcher.last_request.body
+  end
+
+  def test_execute_with_ruby_selector_selects_matching_gem
+    _, other_path = util_gem "ruby-other", "1.0.0", ruby_abi: "3.3" do |spec|
+      spec.files = ["lib/ruby-other.rb"]
+      spec.platform = "arm64-darwin"
+    end
+    _, matching_path = util_gem "ruby-match", "1.0.0", ruby_abi: "3.4" do |spec|
+      spec.files = ["lib/ruby-match.rb"]
+      spec.platform = "arm64-darwin"
+    end
+
+    @response = "Successfully registered gem: ruby-match (1.0.0)"
+    @fetcher.data["#{Gem.host}/api/v1/gems"] = HTTPResponseFactory.create(body: @response, code: 200, msg: "OK")
+
+    @cmd.options[:args] = [other_path, matching_path]
+    @cmd.options[:ruby_abi] = "3.4"
+
+    @cmd.execute
+
+    assert_equal Gem::Net::HTTP::Post, @fetcher.last_request.class
+    assert_equal Gem.read_binary(matching_path), @fetcher.last_request.body
+  end
+
+  def test_execute_with_ruby_abi_selector_rejects_invalid_ruby_abi
+    @cmd.options[:args] = [@path]
+    @cmd.options[:ruby_abi] = "3.4.5"
+
+    error = assert_raise Gem::CommandLineError do
+      @cmd.execute
+    end
+
+    assert_equal "Ruby ABI must be in X.Y format", error.message
+  end
+
+  def test_execute_with_selectors_skips_invalid_gem_package
+    invalid_path = File.join @tempdir, "invalid.gem"
+    File.binwrite invalid_path, "not a gem"
+    _, matching_path = util_gem "skip-invalid", "1.0.0", ruby_abi: "3.4" do |spec|
+      spec.files = ["lib/skip-invalid.rb"]
+      spec.platform = "arm64-darwin"
+    end
+
+    @response = "Successfully registered gem: skip-invalid (1.0.0)"
+    @fetcher.data["#{Gem.host}/api/v1/gems"] = HTTPResponseFactory.create(body: @response, code: 200, msg: "OK")
+
+    @cmd.options[:args] = [invalid_path, matching_path]
+    @cmd.options[:platform] = "arm64-darwin"
+
+    use_ui @ui do
+      @cmd.execute
+    end
+
+    assert_match(/Skipping #{Regexp.escape(invalid_path)}: package metadata is missing/, @ui.error)
+    assert_equal Gem::Net::HTTP::Post, @fetcher.last_request.class
+    assert_equal Gem.read_binary(matching_path), @fetcher.last_request.body
+  end
+
+  def test_execute_with_platform_and_ruby_selectors_selects_matching_gem
+    _, wrong_platform_path = util_gem "both-wrong-platform", "1.0.0", ruby_abi: "3.4" do |spec|
+      spec.files = ["lib/both-wrong-platform.rb"]
+      spec.platform = "x86_64-linux"
+    end
+    _, wrong_ruby_path = util_gem "both-wrong-ruby", "1.0.0", ruby_abi: "3.3" do |spec|
+      spec.files = ["lib/both-wrong-ruby.rb"]
+      spec.platform = "arm64-darwin"
+    end
+    _, matching_path = util_gem "both-match", "1.0.0", ruby_abi: "3.4" do |spec|
+      spec.files = ["lib/both-match.rb"]
+      spec.platform = "arm64-darwin"
+    end
+
+    @response = "Successfully registered gem: both-match (1.0.0)"
+    @fetcher.data["#{Gem.host}/api/v1/gems"] = HTTPResponseFactory.create(body: @response, code: 200, msg: "OK")
+
+    @cmd.options[:args] = [wrong_platform_path, wrong_ruby_path, matching_path]
+    @cmd.options[:platform] = "arm64-darwin"
+    @cmd.options[:ruby_abi] = "3.4"
+
+    @cmd.execute
+
+    assert_equal Gem::Net::HTTP::Post, @fetcher.last_request.class
+    assert_equal Gem.read_binary(matching_path), @fetcher.last_request.body
+  end
+
+  def test_execute_with_same_name_version_platform_selects_matching_ruby_abi
+    _, ruby_33_path = util_gem "same-target", "1.0.0", ruby_abi: "3.3" do |spec|
+      spec.files = ["lib/same-target.rb"]
+      spec.platform = "arm64-darwin"
+    end
+    _, ruby_34_path = util_gem "same-target", "1.0.0", ruby_abi: "3.4" do |spec|
+      spec.files = ["lib/same-target.rb"]
+      spec.platform = "arm64-darwin"
+    end
+
+    @response = "Successfully registered gem: same-target (1.0.0)"
+    @fetcher.data["#{Gem.host}/api/v1/gems"] = HTTPResponseFactory.create(body: @response, code: 200, msg: "OK")
+
+    @cmd.options[:args] = [ruby_33_path, ruby_34_path]
+    @cmd.options[:platform] = "arm64-darwin"
+    @cmd.options[:ruby_abi] = "3.4"
+
+    @cmd.execute
+
+    assert_equal Gem::Net::HTTP::Post, @fetcher.last_request.class
+    assert_equal Gem.read_binary(ruby_34_path), @fetcher.last_request.body
+  end
+
+  def test_execute_with_fat_and_skinny_candidates_selects_skinny_for_ruby_abi
+    _, fat_path = util_gem "mixed-target", "1.0.0" do |spec|
+      spec.platform = "arm64-darwin"
+      spec.required_ruby_version = ">= 3.1"
+    end
+    _, skinny_path = util_gem "mixed-target", "1.0.0", ruby_abi: "3.4" do |spec|
+      spec.files = ["lib/mixed-target.rb"]
+      spec.platform = "arm64-darwin"
+    end
+
+    @response = "Successfully registered gem: mixed-target (1.0.0)"
+    @fetcher.data["#{Gem.host}/api/v1/gems"] = HTTPResponseFactory.create(body: @response, code: 200, msg: "OK")
+
+    @cmd.options[:args] = [fat_path, skinny_path]
+    @cmd.options[:platform] = "arm64-darwin"
+    @cmd.options[:ruby_abi] = "3.4"
+
+    @cmd.execute
+
+    assert_equal Gem::Net::HTTP::Post, @fetcher.last_request.class
+    assert_equal Gem.read_binary(skinny_path), @fetcher.last_request.body
+  end
+
+  def test_execute_with_ruby_abi_selector_does_not_match_broad_ruby_requirement
+    _, gem_path = util_gem "broad-ruby", "1.0.0" do |spec|
+      spec.platform = "arm64-darwin"
+      spec.required_ruby_version = ">= 3.1"
+    end
+
+    @cmd.options[:args] = [gem_path]
+    @cmd.options[:platform] = "arm64-darwin"
+    @cmd.options[:ruby_abi] = "3.4"
+
+    error = assert_raise Gem::CommandLineError do
+      @cmd.execute
+    end
+
+    assert_equal "No gem matched platform arm64-darwin and Ruby ABI 3.4", error.message
+  end
+
+  def test_execute_with_selectors_raises_when_no_gems_match
+    _, gem_path = util_gem "no-match", "1.0.0", ruby_abi: "3.4" do |spec|
+      spec.files = ["lib/no-match.rb"]
+      spec.platform = "arm64-darwin"
+    end
+
+    @cmd.options[:args] = [gem_path]
+    @cmd.options[:platform] = "x86_64-linux"
+    @cmd.options[:ruby_abi] = "3.4"
+
+    error = assert_raise Gem::CommandLineError do
+      @cmd.execute
+    end
+
+    assert_equal "No gem matched platform x86_64-linux and Ruby ABI 3.4", error.message
+  end
+
+  def test_execute_with_selectors_raises_when_multiple_gems_match
+    _, first_path = util_gem "ambiguous-one", "1.0.0", ruby_abi: "3.4" do |spec|
+      spec.files = ["lib/ambiguous-one.rb"]
+      spec.platform = "arm64-darwin"
+    end
+    _, second_path = util_gem "ambiguous-two", "1.0.0", ruby_abi: "3.4" do |spec|
+      spec.files = ["lib/ambiguous-two.rb"]
+      spec.platform = "arm64-darwin"
+    end
+
+    @cmd.options[:args] = [first_path, second_path]
+    @cmd.options[:platform] = "arm64-darwin"
+    @cmd.options[:ruby_abi] = "3.4"
+
+    error = assert_raise Gem::CommandLineError do
+      @cmd.execute
+    end
+
+    assert_match "Multiple gems matched platform arm64-darwin and Ruby ABI 3.4", error.message
+    assert_match first_path, error.message
+    assert_match second_path, error.message
+  end
+
+  def test_execute_with_platform_selector_raises_when_multiple_ruby_abis_match
+    _, ruby_33_path = util_gem "ambiguous-target", "1.0.0", ruby_abi: "3.3" do |spec|
+      spec.files = ["lib/ambiguous-target.rb"]
+      spec.platform = "arm64-darwin"
+    end
+    _, ruby_34_path = util_gem "ambiguous-target", "1.0.0", ruby_abi: "3.4" do |spec|
+      spec.files = ["lib/ambiguous-target.rb"]
+      spec.platform = "arm64-darwin"
+    end
+
+    @cmd.options[:args] = [ruby_33_path, ruby_34_path]
+    @cmd.options[:platform] = "arm64-darwin"
+
+    error = assert_raise Gem::CommandLineError do
+      @cmd.execute
+    end
+
+    assert_match "Multiple gems matched platform arm64-darwin", error.message
+    assert_match ruby_33_path, error.message
+    assert_match ruby_34_path, error.message
+    assert_match "Specify --ruby-abi with one of: 3.3, 3.4", error.message
+  end
+
+  def test_execute_with_ruby_abi_selector_raises_when_multiple_platforms_match
+    _, arm_path = util_gem "ambiguous-platform", "1.0.0", ruby_abi: "3.4" do |spec|
+      spec.files = ["lib/ambiguous-platform.rb"]
+      spec.platform = "arm64-darwin"
+    end
+    _, linux_path = util_gem "ambiguous-platform", "1.0.0", ruby_abi: "3.4" do |spec|
+      spec.files = ["lib/ambiguous-platform.rb"]
+      spec.platform = "x86_64-linux"
+    end
+
+    @cmd.options[:args] = [arm_path, linux_path]
+    @cmd.options[:ruby_abi] = "3.4"
+
+    error = assert_raise Gem::CommandLineError do
+      @cmd.execute
+    end
+
+    assert_match "Multiple gems matched Ruby ABI 3.4", error.message
+    assert_match arm_path, error.message
+    assert_match linux_path, error.message
+    assert_match "Specify --platform with one of: arm64-darwin, x86_64-linux", error.message
+  end
+
+  def test_execute_with_platform_selector_suggests_exact_filename_for_gem_without_ruby_abi
+    _, fat_path = util_gem "ambiguous-fat", "1.0.0" do |spec|
+      spec.platform = "arm64-darwin"
+      spec.required_ruby_version = ">= 3.1"
+    end
+    _, skinny_path = util_gem "ambiguous-fat", "1.0.0", ruby_abi: "3.4" do |spec|
+      spec.files = ["lib/ambiguous-fat.rb"]
+      spec.platform = "arm64-darwin"
+    end
+
+    @cmd.options[:args] = [fat_path, skinny_path]
+    @cmd.options[:platform] = "arm64-darwin"
+
+    error = assert_raise Gem::CommandLineError do
+      @cmd.execute
+    end
+
+    assert_match "Multiple gems matched platform arm64-darwin", error.message
+    assert_match fat_path, error.message
+    assert_match skinny_path, error.message
+    assert_match "Specify --ruby-abi with one of: 3.4", error.message
+    assert_match "To push a gem without a Ruby ABI, pass the exact filename.", error.message
+  end
+
+  def test_execute_without_selectors_still_rejects_multiple_gems
+    _, other_path = util_gem "extra-gem", "1.0.0", ruby_abi: "3.4" do |spec|
+      spec.files = ["lib/extra-gem.rb"]
+      spec.platform = "arm64-darwin"
+    end
+
+    @cmd.options[:args] = [@path, other_path]
+
+    error = assert_raise Gem::CommandLineError do
+      @cmd.execute
+    end
+
+    assert_match "Too many gem names", error.message
+  end
+
   def test_execute_attestation
     @response = "Successfully registered gem: freewill (1.0.0)"
     @fetcher.data["#{Gem.host}/api/v1/gems"] = HTTPResponseFactory.create(body: @response, code: 200, msg: "OK")

--- a/test/rubygems/test_gem_dependency_installer.rb
+++ b/test/rubygems/test_gem_dependency_installer.rb
@@ -373,7 +373,7 @@ class TestGemDependencyInstaller < Gem::TestCase
     end
     e1_gem = e1.cache_file
 
-    _, f1_gem = util_gem "f", "1", "e" => nil
+    _, f1_gem = util_gem "f", "1", { "e" => nil }
 
     Gem::Installer.at(e1_gem).install
     FileUtils.rm_r e1.extension_dir
@@ -394,7 +394,7 @@ class TestGemDependencyInstaller < Gem::TestCase
 
   def test_install_dependency_old
     _, e1_gem = util_gem "e", "1"
-    _, f1_gem = util_gem "f", "1", "e" => nil
+    _, f1_gem = util_gem "f", "1", { "e" => nil }
     _, f2_gem = util_gem "f", "2"
 
     FileUtils.mv e1_gem, @tempdir
@@ -507,7 +507,7 @@ class TestGemDependencyInstaller < Gem::TestCase
   end
 
   def test_install_compact_index_api
-    a1, a1_gem = util_gem "a", 1, "b" => ">= 1"
+    a1, a1_gem = util_gem "a", 1, { "b" => ">= 1" }
     b1, b1_gem = util_gem "b", 1
 
     util_setup_compact_index a1, b1


### PR DESCRIPTION
## What

closes: https://github.com/ruby/rubygems/issues/9728

This PR updates `gem push` so maintainers can select a local gem file by its internal metadata instead of only by filename. This is for the case in which a maintainer may build multiple content-addressed skinny binaries for the same gem version/platform, but `gem push` still pushes one gem at a time. This lets them select the one target they want to push by platform/Ruby ABI instead of manually mapping hashes back to gem metadata.

It adds two selector options: `--platform PLATFORM` `--ruby-abi RUBY_ABI`

When either selector is provided, `gem push` can accept multiple candidate `.gem` files, inspect each file’s internal gemspec, and push the single file that matches the requested platform and/or Ruby ABI.

This PR is stacked on Shopify/rubygems#171, which adds content-addressable gem build support.

## Why

Content-addressable skinny gems use hash-based filenames, for example:

```bash
demo-0.1.0-662574271f.gem
demo-0.1.0-7b9a11c162.gem
```

From the filename alone, a maintainer cannot tell which file is for Ruby ABI `3.3` vs `3.4`.

A maintainer may build multiple skinny gems for the same gem version and platform:

```text
demo / 0.1.0 / arm64-darwin / ruby_abi 3.3
demo / 0.1.0 / arm64-darwin / ruby_abi 3.4
```

With this PR, they can run:

```bash
gem push demo-*.gem --platform arm64-darwin --ruby-abi 3.4
```

and RubyGems will select the matching `.gem` file by reading its internal spec.

If no file matches, or if multiple files match, `gem push` raises an error instead of guessing.

For ambiguous matches, this PR keeps `gem push` scoped to one final file and makes the error actionable. For example, if `--platform arm64-darwin` matches both fat and skinny gems, the error suggests adding `--ruby-abi` to select a skinny gem, or passing the exact filename to push the fat gem.

## Manual tophat

1. Run this from the RubyGems checkout:

<details>
<summary>See Code</summary>

```bash
cd /path/to/rubygems
RUBYGEMS="$PWD"
WORKDIR="$PWD/tmp/ca-gem-push-option-d-tophat"
rm -rf "$WORKDIR"
mkdir -p "$WORKDIR/lib"
cd "$WORKDIR"
printf '# hello\n' > lib/demo.rb

ruby --disable-gems -I"$RUBYGEMS/lib" - <<'RUBY'
require "rubygems"
require "rubygems/package"
require "rubygems/commands/push_command"


def build_ca(name, platform:, ruby_abi:)
  spec = Gem::Specification.new(name, "0.1.0") do |s|
    s.summary = name
    s.authors = ["Tester"]
    s.files = ["lib/demo.rb"]
    s.platform = platform
    s.required_ruby_version = "~> #{ruby_abi}.0"
  end
  Gem::Package.build(spec, false, false, nil, ruby_abi)
end

def build_fat(name, platform:)
  spec = Gem::Specification.new(name, "0.1.0") do |s|
    s.summary = name
    s.authors = ["Tester"]
    s.files = ["lib/demo.rb"]
    s.platform = platform
    s.required_ruby_version = ">= 3.1"
  end
  Gem::Package.build(spec)
end

puts "== Build candidate gems =="
fat = build_fat("demo", platform: "arm64-darwin")
skinny_33 = build_ca("demo", platform: "arm64-darwin", ruby_abi: "3.3")
skinny_34_arm = build_ca("demo", platform: "arm64-darwin", ruby_abi: "3.4")
skinny_34_linux = build_ca("demo", platform: "x86_64-linux", ruby_abi: "3.4")

puts "\n== Candidate metadata =="
Dir["*.gem"].sort.each do |file|
  spec = Gem::Package.new(file).spec
  ruby_abi = spec.ruby_abi || "none"
  kind = ruby_abi == "none" ? "fat/no ruby_abi" : "skinny"
  puts "#{file}"
  puts "  kind: #{kind}"
  puts "  platform: #{spec.platform}"
  puts "  ruby_abi: #{ruby_abi}"
end

cases = [
  ["success: skinny arm64 Ruby ABI 3.4", [skinny_33, skinny_34_arm, skinny_34_linux], { platform: "arm64-darwin", ruby_abi: "3.4" }],
  ["success: fat exact filename", [fat], {}],
  ["ambiguous: platform only with fat + skinny", [fat, skinny_34_arm], { platform: "arm64-darwin" }],
  ["ambiguous: platform only with multiple skinny ABIs", [skinny_33, skinny_34_arm], { platform: "arm64-darwin" }],
  ["ambiguous: Ruby ABI only with multiple platforms", [skinny_34_arm, skinny_34_linux], { ruby_abi: "3.4" }],
  ["no match: wrong platform + Ruby ABI", [skinny_33, skinny_34_arm], { platform: "x86_64-linux", ruby_abi: "3.4" }],
]

puts "\n== gem push selector tophat =="
cases.each do |label, files, options|
  cmd = Gem::Commands::PushCommand.new
  cmd.options[:args] = files
  cmd.options[:platform] = options[:platform] if options[:platform]
  cmd.options[:ruby_abi] = options[:ruby_abi] if options[:ruby_abi]

  selector = []
  selector << "--platform #{options[:platform]}" if options[:platform]
  selector << "--ruby-abi #{options[:ruby_abi]}" if options[:ruby_abi]

  puts "\n#{label}"
  puts "gem push #{files.join(" ")} #{selector.join(" ")}".rstrip

  begin
    selected = cmd.send(:resolve_gem_name, files)
    puts "=> selected: #{selected}"
  rescue Gem::CommandLineError => e
    puts "=> error: #{e.message}"
  end
end
RUBY
```

</details>

2. Expected behavior:

- `--platform arm64-darwin --ruby-abi 3.4` selects the matching skinny gem.
- Passing the exact fat filename selects the fat gem.
- `--platform arm64-darwin` with fat + skinny candidates errors and suggests `--ruby-abi` or exact filename.
- `--platform arm64-darwin` with multiple skinny ABIs errors and suggests available `--ruby-abi` values.
- `--ruby-abi 3.4` with multiple platforms errors and suggests available `--platform` values.
- Non-matching selectors still return a no-match error.
