### PR TITLE
Decode content-addressed gem metadata in remote CLI output

### DIFF
--- a/lib/rubygems/name_tuple.rb
+++ b/lib/rubygems/name_tuple.rb
@@ -48,15 +48,13 @@ class Gem::NameTuple
   # of Gem::Specification#full_name.
 
   def full_name
-    full_name = "#{@name}-#{@version}"
-    suffix = @content_address || platform_suffix
-    suffix ? "#{full_name}-#{suffix}" : full_name
-  end
-
-  private def platform_suffix # :nodoc:
-    return if @platform.nil? || @platform.empty? || @platform == Gem::Platform::RUBY
-
-    @platform
+    if @content_address
+      "#{@name}-#{@version}-#{@content_address}"
+    elsif @platform.nil? || @platform.empty? || @platform == Gem::Platform::RUBY
+      "#{@name}-#{@version}"
+    else
+      "#{@name}-#{@version}-#{@platform}"
+    end
   end
 
   ##
@@ -136,6 +134,6 @@ class Gem::NameTuple
   alias_method :eql?, :==
 
   def hash
-    [@name, @version, @platform, @content_address, @ruby_abi].hash
+    to_a.hash
   end
 end

--- a/lib/rubygems/name_tuple.rb
+++ b/lib/rubygems/name_tuple.rb
@@ -6,16 +6,18 @@
 # wrap the data returned from the indexes.
 
 class Gem::NameTuple
-  def initialize(name, version, platform = Gem::Platform::RUBY)
+  def initialize(name, version, platform = Gem::Platform::RUBY, content_address: nil, ruby_abi: nil)
     @name = name
     @version = version
 
     platform &&= platform.to_s
     platform = Gem::Platform::RUBY if !platform || platform.empty?
     @platform = platform
+    @content_address = content_address unless content_address.nil?
+    @ruby_abi = ruby_abi unless ruby_abi.nil?
   end
 
-  attr_reader :name, :version, :platform
+  attr_reader :name, :version, :platform, :content_address, :ruby_abi
 
   ##
   # Turn an array of [name, version, platform] into an array of
@@ -46,12 +48,15 @@ class Gem::NameTuple
   # of Gem::Specification#full_name.
 
   def full_name
-    case @platform
-    when nil, "", Gem::Platform::RUBY
-      "#{@name}-#{@version}"
-    else
-      "#{@name}-#{@version}-#{@platform}"
-    end
+    full_name = "#{@name}-#{@version}"
+    suffix = @content_address || platform_suffix
+    suffix ? "#{full_name}-#{suffix}" : full_name
+  end
+
+  private def platform_suffix # :nodoc:
+    return if @platform.nil? || @platform.empty? || @platform == Gem::Platform::RUBY
+
+    @platform
   end
 
   ##
@@ -84,18 +89,27 @@ class Gem::NameTuple
   alias_method :deconstruct, :to_a
 
   def deconstruct_keys(keys)
-    { name: @name, version: @version, platform: @platform }
+    {
+      name: @name,
+      version: @version,
+      platform: @platform,
+      content_address: @content_address,
+      ruby_abi: @ruby_abi,
+    }
   end
 
   def inspect # :nodoc:
-    "#<Gem::NameTuple #{@name}, #{@version}, #{@platform}>"
+    "#<Gem::NameTuple name=#{@name} version=#{@version} platform=#{@platform} content_address=#{@content_address} ruby_abi=#{@ruby_abi}>"
   end
 
   alias_method :to_s, :inspect # :nodoc:
 
   def <=>(other)
-    [@name, @version, Gem::Platform.sort_priority(@platform)] <=>
-      [other.name, other.version, Gem::Platform.sort_priority(other.platform)]
+    sort_key <=> other.sort_key
+  end
+
+  def sort_key # :nodoc:
+    [@name, @version, Gem::Platform.sort_priority(@platform), @content_address.to_s, @ruby_abi.to_s]
   end
 
   include Comparable
@@ -109,7 +123,9 @@ class Gem::NameTuple
     when self.class
       @name == other.name &&
         @version == other.version &&
-        @platform == other.platform
+        @platform == other.platform &&
+        @content_address == other.content_address &&
+        @ruby_abi == other.ruby_abi
     when Array
       to_a == other
     else
@@ -120,6 +136,6 @@ class Gem::NameTuple
   alias_method :eql?, :==
 
   def hash
-    to_a.hash
+    [@name, @version, @platform, @content_address, @ruby_abi].hash
   end
 end

--- a/lib/rubygems/query_utils.rb
+++ b/lib/rubygems/query_utils.rb
@@ -154,7 +154,18 @@ module Gem::QueryUtils
       end
     end
 
+    spec_tuples = decode_content_addressable_tuples(spec_tuples, latest: specs_type == :latest)
+
     output_query_results(spec_tuples)
+  end
+
+  def decode_content_addressable_tuples(spec_tuples, latest: false)
+    spec_tuples.group_by {|_, source| source }.flat_map do |source, source_tuples|
+      next source_tuples unless source.respond_to?(:decode_content_addressable_tuples)
+
+      tuples = source_tuples.map(&:first)
+      source.decode_content_addressable_tuples(tuples, latest: latest).map {|tuple| [tuple, source] }
+    end
   end
 
   def specs_type
@@ -200,9 +211,11 @@ module Gem::QueryUtils
       matching_tuples = matching_tuples.sort_by {|n,_| n.version }.reverse
 
       platforms = Hash.new {|h,version| h[version] = [] }
+      platform_ruby_abis = Hash.new {|h,version| h[version] = Hash.new {|hh,platform| hh[platform] = [] } }
 
       matching_tuples.each do |n, _|
         platforms[n.version] << n.platform if n.platform
+        platform_ruby_abis[n.version][n.platform] << n.ruby_abi if n.ruby_abi
       end
 
       seen = {}
@@ -216,11 +229,11 @@ module Gem::QueryUtils
         end
       end
 
-      output << clean_text(make_entry(matching_tuples, platforms))
+      output << clean_text(make_entry(matching_tuples, platforms, platform_ruby_abis))
     end
   end
 
-  def entry_details(entry, detail_tuple, specs, platforms)
+  def entry_details(entry, detail_tuple, specs, platforms, platform_ruby_abis)
     return unless options[:details]
 
     name_tuple, spec = detail_tuple
@@ -229,7 +242,11 @@ module Gem::QueryUtils
 
     entry << "\n"
 
-    spec_platforms   entry, platforms
+    if ruby_abi_metadata?(platform_ruby_abis)
+      spec_platform_ruby_abis entry, platforms, platform_ruby_abis
+    else
+      spec_platforms entry, platforms
+    end
     spec_authors     entry, spec
     spec_homepage    entry, spec
     spec_license     entry, spec
@@ -237,36 +254,63 @@ module Gem::QueryUtils
     spec_summary     entry, spec
   end
 
-  def entry_versions(entry, name_tuples, platforms, specs)
+  def entry_versions(entry, name_tuples, platforms, platform_ruby_abis, specs)
     return unless options[:versions]
 
     list =
       if platforms.empty? || options[:details]
         name_tuples.map(&:version).uniq
+      elsif ruby_abi_metadata?(platform_ruby_abis)
+        platforms.sort.reverse.flat_map do |version, pls|
+          out = version_label(version, specs)
+          labels = version_platform_labels(version, pls, platform_ruby_abis, label_platform: true)
+          labels.empty? ? [out] : labels.map {|label| "#{out} #{label}" }
+        end
       else
         platforms.sort.reverse.map do |version, pls|
-          out = version.to_s
-
-          if options[:domain] == :local
-            default = specs.any? do |s|
-              !s.is_a?(Gem::Source) && s.version == version && s.default_gem?
-            end
-            out = "default: #{out}" if default
-          end
-
-          if pls != [Gem::Platform::RUBY]
-            platform_list = [pls.delete(Gem::Platform::RUBY), *pls.sort].compact
-            out = platform_list.unshift(out).join(" ")
-          end
-
-          out
+          out = version_label(version, specs)
+          labels = version_platform_labels(version, pls, platform_ruby_abis)
+          labels.empty? ? out : "#{out} #{labels.join(" ")}"
         end
       end
 
-    entry << " (#{list.join ", "})"
+    use_multiline_separator = !options[:details] && ruby_abi_metadata?(platform_ruby_abis) && list.length > 1
+    separator = use_multiline_separator ? "\n#{" " * (entry.first.length + 2)}" : ", "
+    entry << " (#{list.join separator})"
   end
 
-  def make_entry(entry_tuples, platforms)
+  def version_label(version, specs)
+    out = version.to_s
+    return out unless options[:domain] == :local
+
+    default = specs.any? do |s|
+      !s.is_a?(Gem::Source) && s.version == version && s.default_gem?
+    end
+    default ? "default: #{out}" : out
+  end
+
+  def ruby_abi_metadata?(platform_ruby_abis)
+    platform_ruby_abis.values.any? do |ruby_abis_by_platform|
+      ruby_abis_by_platform.values.any?(&:any?)
+    end
+  end
+
+  def version_platform_labels(version, platforms, platform_ruby_abis, label_platform: false)
+    platforms = platforms.uniq
+    return [] if platforms == [Gem::Platform::RUBY]
+
+    platforms = [platforms.delete(Gem::Platform::RUBY), *platforms.sort].compact
+    platforms.map do |platform|
+      ruby_abis = platform_ruby_abis[version][platform].uniq.sort
+      platform_label = label_platform ? "Platform: #{platform}" : platform
+      next platform_label if ruby_abis.empty?
+
+      separator = label_platform ? ", " : " "
+      "#{platform_label}#{separator}Ruby ABI: #{ruby_abis.join(", ")}"
+    end
+  end
+
+  def make_entry(entry_tuples, platforms, platform_ruby_abis)
     detail_tuple = entry_tuples.first
 
     name_tuples, specs = entry_tuples.flatten.partition do |item|
@@ -275,8 +319,8 @@ module Gem::QueryUtils
 
     entry = [name_tuples.first.name]
 
-    entry_versions(entry, name_tuples, platforms, specs)
-    entry_details(entry, detail_tuple, specs, platforms)
+    entry_versions(entry, name_tuples, platforms, platform_ruby_abis, specs)
+    entry_details(entry, detail_tuple, specs, platforms, platform_ruby_abis)
 
     entry.join
   end
@@ -319,6 +363,7 @@ module Gem::QueryUtils
   end
 
   def spec_platforms(entry, platforms)
+    platforms = platforms.transform_values(&:uniq)
     non_ruby = platforms.any? do |_, pls|
       pls.any? {|pl| pl != Gem::Platform::RUBY }
     end
@@ -326,7 +371,7 @@ module Gem::QueryUtils
     return unless non_ruby
 
     if platforms.length == 1
-      title = platforms.values.length == 1 ? "Platform" : "Platforms"
+      title = platforms.values.first.length == 1 ? "Platform" : "Platforms"
       entry << "    #{title}: #{platforms.values.sort.join(", ")}\n"
     else
       entry << "    Platforms:\n"
@@ -336,6 +381,26 @@ module Gem::QueryUtils
       sorted_platforms.each do |version, pls|
         label = "        #{version}: "
         data = format_text pls.sort.join(", "), 68, label.length
+        data[0, label.length] = label
+        entry << data << "\n"
+      end
+    end
+  end
+
+  def spec_platform_ruby_abis(entry, platforms, platform_ruby_abis)
+    entry << "    Platforms:\n"
+
+    platforms.sort.each do |version, pls|
+      labels = version_platform_labels(version, pls, platform_ruby_abis)
+      next if labels.empty?
+
+      if platforms.length == 1
+        labels.each do |label|
+          entry << "        #{label}\n"
+        end
+      else
+        label = "        #{version}: "
+        data = format_text labels.join(", "), 68, label.length
         data[0, label.length] = label
         entry << data << "\n"
       end

--- a/lib/rubygems/safe_marshal.rb
+++ b/lib/rubygems/safe_marshal.rb
@@ -51,7 +51,7 @@ module Gem
         @name @requirement @prerelease @version_requirement @version_requirements @type
         @force_ruby_platform
       ],
-      "Gem::NameTuple" => %w[@name @version @platform],
+      "Gem::NameTuple" => %w[@name @version @platform @content_address @ruby_abi],
       "Gem::Platform" => %w[@os @cpu @version],
       "Psych::PrivateType" => %w[@value @type_id],
       "YAML::PrivateType" => %w[@value @type_id],

--- a/lib/rubygems/source.rb
+++ b/lib/rubygems/source.rb
@@ -184,6 +184,37 @@ class Gem::Source
     end
   end
 
+  def decode_content_addressable_tuples(tuples, latest: false) # :nodoc:
+    ca_tuples = tuples.select(&:content_address)
+    return tuples if ca_tuples.empty?
+
+    decoded_tuples = ca_tuples.group_by(&:name).flat_map do |name, name_tuples|
+      rows = name_tuples.map do |tuple|
+        [tuple.name, tuple.version, tuple.version.to_s, tuple.content_address]
+      end
+
+      content_addressable_tuples(name, rows)
+    end
+
+    decoded_by_key = decoded_tuples.to_h do |tuple|
+      [[tuple.name, tuple.version, tuple.content_address], tuple]
+    end
+
+    decoded = tuples.filter_map do |tuple|
+      if tuple.content_address
+        decoded_by_key[[tuple.name, tuple.version, tuple.content_address]]
+      else
+        tuple
+      end
+    end
+
+    return decoded unless latest
+
+    decoded.group_by(&:name).flat_map do |_, name_tuples|
+      max_versions_by_platform(name_tuples)
+    end
+  end
+
   ##
   # Downloads +spec+ and writes it to +dir+.  See also
   # Gem::RemoteFetcher#download.
@@ -259,36 +290,16 @@ class Gem::Source
     tuples = []
 
     versions.each_value do |rows|
-      info_rows = nil
-
-      gem_tuples = rows.filter_map do |name, version_string, suffix|
+      gem_tuples = rows.filter_map do |row_name, version_string, suffix|
         next unless Gem::Version.correct?(version_string)
 
         version = Gem::Version.new(version_string)
         next if version.prerelease? != (type == :prerelease)
 
         suffix ||= "ruby"
-        platform = suffix
-        content_address = nil
-        ruby_abi = nil
+        content_address = suffix if Gem::ContentAddress.match?(suffix)
 
-        if Gem::ContentAddress.match?(suffix)
-          info_rows ||= compact_index_info_rows(name)
-          metadata = content_addressable_metadata(info_rows, version_string, suffix)
-          next unless metadata
-
-          platform = metadata[:platform]
-          content_address = suffix
-          ruby_abi = metadata[:ruby_abi]
-        end
-
-        Gem::NameTuple.new(
-          name,
-          version,
-          platform,
-          content_address: content_address,
-          ruby_abi: ruby_abi
-        )
+        Gem::NameTuple.new(row_name, version, suffix, content_address: content_address)
       end
 
       gem_tuples = max_versions_by_platform(gem_tuples) if type == :latest
@@ -312,27 +323,43 @@ class Gem::Source
     []
   end
 
-  def compact_index_info_row(info_rows, version, suffix)
-    info_rows.find do |row|
-      row_version = row[Gem::CompactIndexClient::INFO_VERSION]
-      row_suffix = row[Gem::CompactIndexClient::INFO_PLATFORM]
+  def content_addressable_tuples(name, rows)
+    metadata = content_addressable_metadata(name, rows)
 
-      row_version == version && row_suffix == suffix
+    rows.filter_map do |row_name, version, version_string, suffix|
+      row_metadata = metadata[[version_string, suffix]]
+      next unless row_metadata
+
+      Gem::NameTuple.new(
+        row_name,
+        version,
+        row_metadata[:platform],
+        content_address: suffix,
+        ruby_abi: row_metadata[:ruby_abi]
+      )
     end
   end
 
-  def content_addressable_metadata(info_rows, version, suffix)
-    info_row = compact_index_info_row(info_rows, version, suffix)
-    return unless info_row
+  def content_addressable_metadata(name, rows)
+    wanted_rows = rows.to_h do |_, _, version, suffix|
+      [[version, suffix], true]
+    end
 
-    requirements = compact_index_requirements(info_row)
-    platform = required_platform_from(requirements[:platform])
-    return unless platform
+    compact_index_info_rows(name).each_with_object({}) do |info_row, metadata|
+      version = info_row[Gem::CompactIndexClient::INFO_VERSION]
+      suffix = info_row[Gem::CompactIndexClient::INFO_PLATFORM]
+      key = [version, suffix]
+      next unless wanted_rows[key]
 
-    {
-      platform: platform,
-      ruby_abi: ruby_abi_from(requirements[:ruby]),
-    }
+      requirements = compact_index_requirements(info_row)
+      platform = required_platform_from(requirements[:platform])
+      next unless platform
+
+      metadata[key] = {
+        platform: platform,
+        ruby_abi: ruby_abi_from(requirements[:ruby]),
+      }
+    end
   end
 
   def compact_index_requirements(info_row)

--- a/lib/rubygems/source.rb
+++ b/lib/rubygems/source.rb
@@ -259,13 +259,36 @@ class Gem::Source
     tuples = []
 
     versions.each_value do |rows|
-      gem_tuples = rows.filter_map do |name, version_string, platform|
+      info_rows = nil
+
+      gem_tuples = rows.filter_map do |name, version_string, suffix|
         next unless Gem::Version.correct?(version_string)
 
         version = Gem::Version.new(version_string)
         next if version.prerelease? != (type == :prerelease)
 
-        Gem::NameTuple.new(name, version, platform || "ruby")
+        suffix ||= "ruby"
+        platform = suffix
+        content_address = nil
+        ruby_abi = nil
+
+        if Gem::ContentAddress.match?(suffix)
+          info_rows ||= compact_index_info_rows(name)
+          metadata = content_addressable_metadata(info_rows, version_string, suffix)
+          next unless metadata
+
+          platform = metadata[:platform]
+          content_address = suffix
+          ruby_abi = metadata[:ruby_abi]
+        end
+
+        Gem::NameTuple.new(
+          name,
+          version,
+          platform,
+          content_address: content_address,
+          ruby_abi: ruby_abi
+        )
       end
 
       gem_tuples = max_versions_by_platform(gem_tuples) if type == :latest
@@ -283,8 +306,71 @@ class Gem::Source
     nil
   end
 
+  def compact_index_info_rows(name)
+    compact_index_client.info(name)
+  rescue Gem::RemoteFetcher::FetchError, Gem::CompactIndexClient::Error
+    []
+  end
+
+  def compact_index_info_row(info_rows, version, suffix)
+    info_rows.find do |row|
+      row_version = row[Gem::CompactIndexClient::INFO_VERSION]
+      row_suffix = row[Gem::CompactIndexClient::INFO_PLATFORM]
+
+      row_version == version && row_suffix == suffix
+    end
+  end
+
+  def content_addressable_metadata(info_rows, version, suffix)
+    info_row = compact_index_info_row(info_rows, version, suffix)
+    return unless info_row
+
+    requirements = compact_index_requirements(info_row)
+    platform = required_platform_from(requirements[:platform])
+    return unless platform
+
+    {
+      platform: platform,
+      ruby_abi: ruby_abi_from(requirements[:ruby]),
+    }
+  end
+
+  def compact_index_requirements(info_row)
+    info_row[Gem::CompactIndexClient::INFO_REQS].to_h do |key, requirements|
+      [key.to_sym, requirements]
+    end
+  end
+
+  def required_platform_from(requirement)
+    platform_requirement = Array(requirement).last.to_s
+    operator, platform = platform_requirement.split(" ", 2)
+    return unless operator == "=" && platform
+
+    platform
+  end
+
+  def ruby_abi_from(requirement)
+    Array(requirement).each do |ruby_requirement|
+      match = ruby_requirement.to_s.match(/\A~>\s*(\d+)\.(\d+)\.0\z/)
+      return "#{match[1]}.#{match[2]}" if match
+    end
+
+    nil
+  end
+
   def max_versions_by_platform(tuples)
-    tuples.group_by(&:platform).map {|_, platform_tuples| platform_tuples.max_by(&:version) }
+    grouped_tuples = tuples.group_by {|tuple| latest_platform_key(tuple) }
+    grouped_tuples.map do |_, platform_tuples|
+      platform_tuples.max_by(&:version)
+    end
+  end
+
+  def latest_platform_key(tuple)
+    if tuple.content_address
+      [tuple.platform, tuple.ruby_abi || tuple.content_address]
+    else
+      tuple.platform
+    end
   end
 
   def compact_index_uri

--- a/test/rubygems/test_gem_commands_info_command.rb
+++ b/test/rubygems/test_gem_commands_info_command.rb
@@ -42,6 +42,119 @@ class TestGemCommandsInfoCommand < Gem::TestCase
     assert_match "", @ui.error
   end
 
+  def test_execute_remote_content_addressable_gem_displays_real_platform_and_ruby_abi
+    spec_fetcher {}
+
+    spec = util_spec "a", "1" do |s|
+      s.platform = "x86_64-linux"
+      s.summary = "this is a summary"
+      s.homepage = "http://example.com"
+      s.authors = ["A User"]
+    end
+    spec.content_address = "abcdef12"
+
+    versions_body = +"created_at: 2026-01-01T00:00:00Z\n---\na 1-abcdef12 0000\n"
+    versions_response = util_compact_index_response(versions_body)
+    versions_response.uri = Gem::URI("#{@gem_repo}versions")
+    @fetcher.data["#{@gem_repo}versions"] = versions_response
+    @fetcher.data["#{@gem_repo}info/a"] = util_compact_index_response("---\n1-abcdef12 |checksum:123,ruby:~> 3.3.0,platform:= x86_64-linux\n")
+
+    path = "#{@gem_repo}quick/Marshal.#{Gem.marshal_version}/a-1-abcdef12.gemspec.rz"
+    @fetcher.data[path] = Zlib::Deflate.deflate(Marshal.dump(spec))
+    Gem::SpecFetcher.fetcher = nil
+
+    @cmd.handle_options %w[a --remote]
+
+    use_ui @ui do
+      @cmd.execute
+    end
+
+    assert_include @ui.output, "Platforms:\n"
+    assert_include @ui.output, "        x86_64-linux Ruby ABI: 3.3\n"
+    refute_match "abcdef12", @ui.output
+  end
+
+  def test_execute_remote_content_addressable_gem_displays_ruby_abis_next_to_their_platforms
+    spec_fetcher {}
+
+    spec = util_spec "a", "1" do |s|
+      s.platform = "x86_64-linux"
+      s.summary = "this is a summary"
+      s.homepage = "http://example.com"
+      s.authors = ["A User"]
+    end
+    spec.content_address = "abcdef12"
+
+    versions_body = +"created_at: 2026-01-01T00:00:00Z\n---\na 1-abcdef12,1-fedcba98 0000\n"
+    versions_response = util_compact_index_response(versions_body)
+    versions_response.uri = Gem::URI("#{@gem_repo}versions")
+    @fetcher.data["#{@gem_repo}versions"] = versions_response
+    @fetcher.data["#{@gem_repo}info/a"] = util_compact_index_response(<<~INFO)
+      ---
+      1-abcdef12 |checksum:123,ruby:~> 3.3.0,platform:= x86_64-linux
+      1-fedcba98 |checksum:456,ruby:~> 3.4.0,platform:= x86_64-linux-musl
+    INFO
+
+    path = "#{@gem_repo}quick/Marshal.#{Gem.marshal_version}/a-1-abcdef12.gemspec.rz"
+    @fetcher.data[path] = Zlib::Deflate.deflate(Marshal.dump(spec))
+    path = "#{@gem_repo}quick/Marshal.#{Gem.marshal_version}/a-1-fedcba98.gemspec.rz"
+    @fetcher.data[path] = Zlib::Deflate.deflate(Marshal.dump(spec))
+    Gem::SpecFetcher.fetcher = nil
+
+    @cmd.handle_options %w[a --remote]
+
+    use_ui @ui do
+      @cmd.execute
+    end
+
+    assert_include @ui.output, "Platforms:\n"
+    assert_include @ui.output, "        x86_64-linux Ruby ABI: 3.3\n"
+    assert_include @ui.output, "        x86_64-linux-musl Ruby ABI: 3.4\n"
+    refute_match "Ruby ABIs: 3.3, 3.4", @ui.output
+    refute_match "abcdef12", @ui.output
+    refute_match "fedcba98", @ui.output
+  end
+
+  def test_execute_remote_content_addressable_and_platform_gems_display_together
+    spec_fetcher {}
+
+    spec = util_spec "a", "3" do |s|
+      s.platform = "arm64-darwin"
+      s.summary = "this is a summary"
+      s.homepage = "http://example.com"
+      s.authors = ["A User"]
+    end
+    spec.content_address = "fedcba98"
+
+    versions_body = +"created_at: 2026-01-01T00:00:00Z\n---\na 1-x86_64-linux,2-abcdef12,3-fedcba98 0000\n"
+    versions_response = util_compact_index_response(versions_body)
+    versions_response.uri = Gem::URI("#{@gem_repo}versions")
+    @fetcher.data["#{@gem_repo}versions"] = versions_response
+    @fetcher.data["#{@gem_repo}info/a"] = util_compact_index_response(<<~INFO)
+      ---
+      2-abcdef12 |checksum:123,ruby:~> 3.3.0,platform:= x86_64-linux
+      3-fedcba98 |checksum:456,ruby:~> 3.4.0,platform:= arm64-darwin
+    INFO
+
+    path = "#{@gem_repo}quick/Marshal.#{Gem.marshal_version}/a-3-fedcba98.gemspec.rz"
+    @fetcher.data[path] = Zlib::Deflate.deflate(Marshal.dump(spec))
+    Gem::SpecFetcher.fetcher = nil
+
+    @cmd.handle_options %w[a --remote --all]
+
+    use_ui @ui do
+      @cmd.execute
+    end
+
+    assert_include @ui.output, "a (3, 2, 1)"
+    assert_include @ui.output, "Platforms:\n"
+    assert_include @ui.output, "        1: x86_64-linux\n"
+    assert_include @ui.output, "        2: x86_64-linux Ruby ABI: 3.3\n"
+    assert_include @ui.output, "        3: arm64-darwin Ruby ABI: 3.4\n"
+    refute_match "abcdef12", @ui.output
+    refute_match "fedcba98", @ui.output
+  end
+
   def test_execute_with_version_flag
     spec_fetcher do |fetcher|
       fetcher.spec "coolgem", "1.0"

--- a/test/rubygems/test_gem_commands_list_command.rb
+++ b/test/rubygems/test_gem_commands_list_command.rb
@@ -31,6 +31,165 @@ class TestGemCommandsListCommand < Gem::TestCase
     assert_equal "", @ui.error
   end
 
+  def test_execute_remote_content_addressable_gem_displays_real_platform_and_ruby_abi
+    spec_fetcher {}
+
+    versions_body = +"created_at: 2026-01-01T00:00:00Z\n---\na 1-abcdef12 0000\nb 1-fedcba98 0000\n"
+    versions_response = util_compact_index_response(versions_body)
+    versions_response.uri = Gem::URI("#{@gem_repo}versions")
+    @fetcher.data["#{@gem_repo}versions"] = versions_response
+    @fetcher.data["#{@gem_repo}info/a"] = util_compact_index_response("---\n1-abcdef12 |checksum:123,ruby:~> 3.3.0,platform:= x86_64-linux\n")
+    @fetcher.data["#{@gem_repo}info/b"] = util_compact_index_response("---\n1-fedcba98 |checksum:123,ruby:~> 3.4.0,platform:= x86_64-linux\n")
+    Gem::SpecFetcher.fetcher = nil
+
+    @cmd.handle_options %w[a --remote]
+
+    use_ui @ui do
+      @cmd.execute
+    end
+
+    assert_include @ui.output, "a (1 Platform: x86_64-linux, Ruby ABI: 3.3)"
+    refute_match "abcdef12", @ui.output
+    refute @fetcher.requests.any? {|req| req.path.end_with?("/info/b") }
+  end
+
+  def test_execute_remote_content_addressable_gems_displays_ruby_abis_next_to_their_platforms
+    spec_fetcher {}
+
+    versions_body = +"created_at: 2026-01-01T00:00:00Z\n---\na 1-abcdef12,1-fedcba98 0000\n"
+    versions_response = util_compact_index_response(versions_body)
+    versions_response.uri = Gem::URI("#{@gem_repo}versions")
+    @fetcher.data["#{@gem_repo}versions"] = versions_response
+    @fetcher.data["#{@gem_repo}info/a"] = util_compact_index_response(<<~INFO)
+      ---
+      1-abcdef12 |checksum:123,ruby:~> 3.3.0,platform:= x86_64-linux
+      1-fedcba98 |checksum:456,ruby:~> 3.4.0,platform:= arm64-darwin
+    INFO
+    Gem::SpecFetcher.fetcher = nil
+
+    @cmd.handle_options %w[a --remote]
+
+    use_ui @ui do
+      @cmd.execute
+    end
+
+    expected = <<~OUTPUT.chomp
+      a (1 Platform: arm64-darwin, Ruby ABI: 3.4
+         1 Platform: x86_64-linux, Ruby ABI: 3.3)
+    OUTPUT
+
+    assert_include @ui.output, expected
+    refute_match "abcdef12", @ui.output
+    refute_match "fedcba98", @ui.output
+  end
+
+  def test_execute_remote_content_addressable_gems_displays_multiple_ruby_abis_on_the_same_line
+    spec_fetcher {}
+
+    versions_body = +"created_at: 2026-01-01T00:00:00Z\n---\na 1-abcdef12,1-fedcba98 0000\n"
+    versions_response = util_compact_index_response(versions_body)
+    versions_response.uri = Gem::URI("#{@gem_repo}versions")
+    @fetcher.data["#{@gem_repo}versions"] = versions_response
+    @fetcher.data["#{@gem_repo}info/a"] = util_compact_index_response(<<~INFO)
+      ---
+      1-abcdef12 |checksum:123,ruby:~> 3.3.0,platform:= x86_64-linux
+      1-fedcba98 |checksum:456,ruby:~> 3.4.0,platform:= x86_64-linux
+    INFO
+    Gem::SpecFetcher.fetcher = nil
+
+    @cmd.handle_options %w[a --remote]
+
+    use_ui @ui do
+      @cmd.execute
+    end
+
+    assert_include @ui.output, "a (1 Platform: x86_64-linux, Ruby ABI: 3.3, 3.4)"
+    refute_match "abcdef12", @ui.output
+    refute_match "fedcba98", @ui.output
+  end
+
+  def test_execute_remote_content_addressable_gems_displays_multiple_versions_on_separate_lines
+    spec_fetcher {}
+
+    versions_body = +"created_at: 2026-01-01T00:00:00Z\n---\na 1-abcdef12,2-fedcba98,3-12345678 0000\n"
+    versions_response = util_compact_index_response(versions_body)
+    versions_response.uri = Gem::URI("#{@gem_repo}versions")
+    @fetcher.data["#{@gem_repo}versions"] = versions_response
+    @fetcher.data["#{@gem_repo}info/a"] = util_compact_index_response(<<~INFO)
+      ---
+      1-abcdef12 |checksum:123,ruby:~> 3.3.0,platform:= x86_64-linux
+      2-fedcba98 |checksum:456,ruby:~> 3.4.0,platform:= x86_64-linux
+      3-12345678 |checksum:789,ruby:~> 3.4.0,platform:= arm64-darwin
+    INFO
+    Gem::SpecFetcher.fetcher = nil
+
+    @cmd.handle_options %w[a --remote]
+
+    use_ui @ui do
+      @cmd.execute
+    end
+
+    expected = <<~OUTPUT.chomp
+      a (3 Platform: arm64-darwin, Ruby ABI: 3.4
+         2 Platform: x86_64-linux, Ruby ABI: 3.4
+         1 Platform: x86_64-linux, Ruby ABI: 3.3)
+    OUTPUT
+
+    assert_include @ui.output, expected
+    refute_match "abcdef12", @ui.output
+    refute_match "fedcba98", @ui.output
+    refute_match "12345678", @ui.output
+  end
+
+  def test_execute_remote_content_addressable_and_platform_gems_display_together
+    spec_fetcher {}
+
+    versions_body = +"created_at: 2026-01-01T00:00:00Z\n---\na 1-x86_64-linux,2-abcdef12,3-fedcba98 0000\n"
+    versions_response = util_compact_index_response(versions_body)
+    versions_response.uri = Gem::URI("#{@gem_repo}versions")
+    @fetcher.data["#{@gem_repo}versions"] = versions_response
+    @fetcher.data["#{@gem_repo}info/a"] = util_compact_index_response(<<~INFO)
+      ---
+      2-abcdef12 |checksum:123,ruby:~> 3.3.0,platform:= x86_64-linux
+      3-fedcba98 |checksum:456,ruby:~> 3.4.0,platform:= arm64-darwin
+    INFO
+    Gem::SpecFetcher.fetcher = nil
+
+    @cmd.handle_options %w[a --remote --all]
+
+    use_ui @ui do
+      @cmd.execute
+    end
+
+    expected = <<~OUTPUT.chomp
+      a (3 Platform: arm64-darwin, Ruby ABI: 3.4
+         2 Platform: x86_64-linux, Ruby ABI: 3.3
+         1 Platform: x86_64-linux)
+    OUTPUT
+
+    assert_include @ui.output, expected
+    refute_match "abcdef12", @ui.output
+    refute_match "fedcba98", @ui.output
+  end
+
+  def test_execute_remote_platform_gem_displays_version_once_for_multiple_platforms
+    spec_fetcher {}
+
+    versions_body = +"created_at: 2026-01-01T00:00:00Z\n---\ne 1-x86_64-linux,1-arm64-darwin 0000\n"
+    versions_response = util_compact_index_response(versions_body)
+    versions_response.uri = Gem::URI("#{@gem_repo}versions")
+    @fetcher.data["#{@gem_repo}versions"] = versions_response
+    Gem::SpecFetcher.fetcher = nil
+
+    @cmd.handle_options %w[e --remote]
+
+    use_ui @ui do
+      @cmd.execute
+    end
+
+    assert_include @ui.output, "e (1 arm64-darwin x86_64-linux)"
+  end
+
   def test_execute_normal_gem_shadowing_default_gem
     c1_default = new_default_spec "c", 1
     install_default_gems c1_default

--- a/test/rubygems/test_gem_commands_search_command.rb
+++ b/test/rubygems/test_gem_commands_search_command.rb
@@ -13,4 +13,55 @@ class TestGemCommandsSearchCommand < Gem::TestCase
   def test_initialize
     assert_equal :remote, @cmd.defaults[:domain]
   end
+
+  def test_execute_content_addressable_gem_displays_real_platform_and_ruby_abi
+    spec_fetcher {}
+
+    versions_body = +"created_at: 2026-01-01T00:00:00Z\n---\na 1-abcdef12 0000\n"
+    versions_response = util_compact_index_response(versions_body)
+    versions_response.uri = Gem::URI("#{@gem_repo}versions")
+    @fetcher.data["#{@gem_repo}versions"] = versions_response
+    @fetcher.data["#{@gem_repo}info/a"] = util_compact_index_response("---\n1-abcdef12 |checksum:123,ruby:~> 3.3.0,platform:= x86_64-linux\n")
+    Gem::SpecFetcher.fetcher = nil
+
+    @cmd.handle_options %w[a]
+
+    use_ui @ui do
+      @cmd.execute
+    end
+
+    assert_include @ui.output, "a (1 Platform: x86_64-linux, Ruby ABI: 3.3)"
+    refute_match "abcdef12", @ui.output
+  end
+
+  def test_execute_content_addressable_and_platform_gems_display_together
+    spec_fetcher {}
+
+    versions_body = +"created_at: 2026-01-01T00:00:00Z\n---\na 1-x86_64-linux,2-abcdef12,3-fedcba98 0000\n"
+    versions_response = util_compact_index_response(versions_body)
+    versions_response.uri = Gem::URI("#{@gem_repo}versions")
+    @fetcher.data["#{@gem_repo}versions"] = versions_response
+    @fetcher.data["#{@gem_repo}info/a"] = util_compact_index_response(<<~INFO)
+      ---
+      2-abcdef12 |checksum:123,ruby:~> 3.3.0,platform:= x86_64-linux
+      3-fedcba98 |checksum:456,ruby:~> 3.4.0,platform:= arm64-darwin
+    INFO
+    Gem::SpecFetcher.fetcher = nil
+
+    @cmd.handle_options %w[a --all]
+
+    use_ui @ui do
+      @cmd.execute
+    end
+
+    expected = <<~OUTPUT.chomp
+      a (3 Platform: arm64-darwin, Ruby ABI: 3.4
+         2 Platform: x86_64-linux, Ruby ABI: 3.3
+         1 Platform: x86_64-linux)
+    OUTPUT
+
+    assert_include @ui.output, expected
+    refute_match "abcdef12", @ui.output
+    refute_match "fedcba98", @ui.output
+  end
 end

--- a/test/rubygems/test_gem_name_tuple.rb
+++ b/test/rubygems/test_gem_name_tuple.rb
@@ -46,6 +46,30 @@ class TestGemNameTuple < Gem::TestCase
     assert_equal a.hash, b.hash
   end
 
+  def test_content_addressable_metadata
+    n = Gem::NameTuple.new "a", Gem::Version.new(1), "x86_64-linux", content_address: "abcdef12", ruby_abi: "3.3"
+
+    assert_equal "abcdef12", n.content_address
+    assert_equal "3.3", n.ruby_abi
+    assert_equal "a-1-abcdef12", n.full_name
+  end
+
+  def test_fat_tuple_does_not_store_nil_content_addressable_metadata_ivars
+    n = Gem::NameTuple.new "a", Gem::Version.new(1), "x86_64-linux"
+
+    refute_includes n.instance_variables, :@content_address
+    refute_includes n.instance_variables, :@ruby_abi
+    assert_nil n.content_address
+    assert_nil n.ruby_abi
+  end
+
+  def test_sort_mixed_fat_and_content_addressable_tuples
+    fat = Gem::NameTuple.new "a", Gem::Version.new(1), "x86_64-linux"
+    skinny = Gem::NameTuple.new "a", Gem::Version.new(1), "x86_64-linux", content_address: "abcdef12", ruby_abi: "3.3"
+
+    assert_equal [fat, skinny], [skinny, fat].sort
+  end
+
   def test_spec_name
     n = Gem::NameTuple.new "a", Gem::Version.new(0), "ruby"
     assert_equal "a-0.gemspec", n.spec_name

--- a/test/rubygems/test_gem_safe_marshal.rb
+++ b/test/rubygems/test_gem_safe_marshal.rb
@@ -344,7 +344,7 @@ class TestGemSafeMarshal < Gem::TestCase
     end
   end
 
-  def test_name_tuple_unmarshall_content_addressable_metadata
+  def test_name_tuple_unmarshal_content_addressable_metadata
     tuple = Gem::NameTuple.new(
       "a",
       Gem::Version.new("1"),
@@ -363,7 +363,7 @@ class TestGemSafeMarshal < Gem::TestCase
     assert_equal "a-1-abcdef12", unmarshalled_tuple.full_name
   end
 
-  def test_name_tuple_unmarshall_legacy_payload_without_content_addressable_metadata
+  def test_name_tuple_unmarshal_legacy_payload_without_content_addressable_metadata
     tuple = Gem::NameTuple.allocate
     tuple.instance_variable_set :@name, "a"
     tuple.instance_variable_set :@version, Gem::Version.new("1")

--- a/test/rubygems/test_gem_safe_marshal.rb
+++ b/test/rubygems/test_gem_safe_marshal.rb
@@ -344,6 +344,41 @@ class TestGemSafeMarshal < Gem::TestCase
     end
   end
 
+  def test_name_tuple_unmarshall_content_addressable_metadata
+    tuple = Gem::NameTuple.new(
+      "a",
+      Gem::Version.new("1"),
+      "x86_64-linux",
+      content_address: "abcdef12",
+      ruby_abi: "3.3"
+    )
+
+    unmarshalled_tuple = Gem::SafeMarshal.safe_load(Marshal.dump(tuple))
+
+    assert_equal "a", unmarshalled_tuple.name
+    assert_equal Gem::Version.new("1"), unmarshalled_tuple.version
+    assert_equal "x86_64-linux", unmarshalled_tuple.platform
+    assert_equal "abcdef12", unmarshalled_tuple.content_address
+    assert_equal "3.3", unmarshalled_tuple.ruby_abi
+    assert_equal "a-1-abcdef12", unmarshalled_tuple.full_name
+  end
+
+  def test_name_tuple_unmarshall_legacy_payload_without_content_addressable_metadata
+    tuple = Gem::NameTuple.allocate
+    tuple.instance_variable_set :@name, "a"
+    tuple.instance_variable_set :@version, Gem::Version.new("1")
+    tuple.instance_variable_set :@platform, "x86_64-linux"
+
+    unmarshalled_tuple = Gem::SafeMarshal.safe_load(Marshal.dump(tuple))
+
+    assert_equal "a", unmarshalled_tuple.name
+    assert_equal Gem::Version.new("1"), unmarshalled_tuple.version
+    assert_equal "x86_64-linux", unmarshalled_tuple.platform
+    assert_nil unmarshalled_tuple.content_address
+    assert_nil unmarshalled_tuple.ruby_abi
+    assert_equal "a-1-x86_64-linux", unmarshalled_tuple.full_name
+  end
+
   def test_gem_spec_unmarshall_license
     spec = Gem::Specification.new do |s|
       s.name = "hi"

--- a/test/rubygems/test_gem_source.rb
+++ b/test/rubygems/test_gem_source.rb
@@ -168,6 +168,72 @@ class TestGemSource < Gem::TestCase
     assert File.exist?(File.join(cache_dir, "versions")), "versions cache file does not exist"
   end
 
+  def test_load_specs_compact_index_content_addressable_metadata
+    versions_body = +"created_at: 2026-01-01T00:00:00Z\n---\na 1-abcdef12 0000\n"
+    versions_response = util_compact_index_response(versions_body)
+    versions_response.uri = Gem::URI("#{@gem_repo}versions")
+    @fetcher.data["#{@gem_repo}versions"] = versions_response
+    @fetcher.data["#{@gem_repo}info/a"] = util_compact_index_response("---\n1-abcdef12 |checksum:123,ruby:~> 3.3.0,platform:= x86_64-linux\n")
+
+    spec = @source.load_specs(:released).first
+
+    assert_equal "a-1-abcdef12", spec.full_name
+    assert_equal "x86_64-linux", spec.platform
+    assert_equal "abcdef12", spec.content_address
+    assert_equal "3.3", spec.ruby_abi
+  end
+
+  def test_load_specs_compact_index_skips_content_addressable_rows_without_metadata
+    versions_body = +"created_at: 2026-01-01T00:00:00Z\n---\na 1-abcdef12 0000\n"
+    versions_response = util_compact_index_response(versions_body)
+    versions_response.uri = Gem::URI("#{@gem_repo}versions")
+    @fetcher.data["#{@gem_repo}versions"] = versions_response
+    @fetcher.data["#{@gem_repo}info/a"] = util_compact_index_response("---\n")
+
+    assert_empty @source.load_specs(:released)
+  end
+
+  def test_load_specs_compact_index_skips_content_addressable_rows_without_required_platform
+    versions_body = +"created_at: 2026-01-01T00:00:00Z\n---\na 1-abcdef12 0000\n"
+    versions_response = util_compact_index_response(versions_body)
+    versions_response.uri = Gem::URI("#{@gem_repo}versions")
+    @fetcher.data["#{@gem_repo}versions"] = versions_response
+    @fetcher.data["#{@gem_repo}info/a"] = util_compact_index_response("---\n1-abcdef12 |checksum:123,ruby:~> 3.3.0\n")
+
+    assert_empty @source.load_specs(:released)
+  end
+
+  def test_load_specs_compact_index_does_not_infer_ruby_abi_from_broad_ruby_requirement
+    versions_body = +"created_at: 2026-01-01T00:00:00Z\n---\na 1-abcdef12 0000\n"
+    versions_response = util_compact_index_response(versions_body)
+    versions_response.uri = Gem::URI("#{@gem_repo}versions")
+    @fetcher.data["#{@gem_repo}versions"] = versions_response
+    @fetcher.data["#{@gem_repo}info/a"] = util_compact_index_response("---\n1-abcdef12 |checksum:123,ruby:>= 3.3,platform:= x86_64-linux\n")
+
+    spec = @source.load_specs(:released).first
+
+    assert_equal "x86_64-linux", spec.platform
+    assert_equal "abcdef12", spec.content_address
+    assert_nil spec.ruby_abi
+  end
+
+  def test_load_specs_compact_index_latest_keeps_content_addressable_ruby_abi_variants
+    versions_body = +"created_at: 2026-01-01T00:00:00Z\n---\na 1-abcdef12,1-fedcba98 0000\n"
+    versions_response = util_compact_index_response(versions_body)
+    versions_response.uri = Gem::URI("#{@gem_repo}versions")
+    @fetcher.data["#{@gem_repo}versions"] = versions_response
+    @fetcher.data["#{@gem_repo}info/a"] = util_compact_index_response(<<~INFO)
+      ---
+      1-abcdef12 |checksum:123,ruby:~> 3.3.0,platform:= x86_64-linux
+      1-fedcba98 |checksum:456,ruby:~> 3.4.0,platform:= x86_64-linux
+    INFO
+
+    specs = @source.load_specs(:latest)
+
+    assert_equal %w[a-1-abcdef12 a-1-fedcba98], specs.map(&:full_name).sort
+    assert_equal %w[3.3 3.4], specs.map(&:ruby_abi).sort
+  end
+
   def test_load_specs_compact_index_latest_per_platform
     a1 = util_spec "a", "1"
     a2_java = util_spec "a", "2" do |s|

--- a/test/rubygems/test_gem_source.rb
+++ b/test/rubygems/test_gem_source.rb
@@ -175,7 +175,10 @@ class TestGemSource < Gem::TestCase
     @fetcher.data["#{@gem_repo}versions"] = versions_response
     @fetcher.data["#{@gem_repo}info/a"] = util_compact_index_response("---\n1-abcdef12 |checksum:123,ruby:~> 3.3.0,platform:= x86_64-linux\n")
 
-    spec = @source.load_specs(:released).first
+    specs = @source.load_specs(:released)
+    refute @fetcher.requests.any? {|req| req.path.end_with?("/info/a") }
+
+    spec = @source.decode_content_addressable_tuples(specs).first
 
     assert_equal "a-1-abcdef12", spec.full_name
     assert_equal "x86_64-linux", spec.platform
@@ -190,7 +193,9 @@ class TestGemSource < Gem::TestCase
     @fetcher.data["#{@gem_repo}versions"] = versions_response
     @fetcher.data["#{@gem_repo}info/a"] = util_compact_index_response("---\n")
 
-    assert_empty @source.load_specs(:released)
+    specs = @source.load_specs(:released)
+
+    assert_empty @source.decode_content_addressable_tuples(specs)
   end
 
   def test_load_specs_compact_index_skips_content_addressable_rows_without_required_platform
@@ -200,7 +205,9 @@ class TestGemSource < Gem::TestCase
     @fetcher.data["#{@gem_repo}versions"] = versions_response
     @fetcher.data["#{@gem_repo}info/a"] = util_compact_index_response("---\n1-abcdef12 |checksum:123,ruby:~> 3.3.0\n")
 
-    assert_empty @source.load_specs(:released)
+    specs = @source.load_specs(:released)
+
+    assert_empty @source.decode_content_addressable_tuples(specs)
   end
 
   def test_load_specs_compact_index_does_not_infer_ruby_abi_from_broad_ruby_requirement
@@ -210,7 +217,7 @@ class TestGemSource < Gem::TestCase
     @fetcher.data["#{@gem_repo}versions"] = versions_response
     @fetcher.data["#{@gem_repo}info/a"] = util_compact_index_response("---\n1-abcdef12 |checksum:123,ruby:>= 3.3,platform:= x86_64-linux\n")
 
-    spec = @source.load_specs(:released).first
+    spec = @source.decode_content_addressable_tuples(@source.load_specs(:released)).first
 
     assert_equal "x86_64-linux", spec.platform
     assert_equal "abcdef12", spec.content_address
@@ -228,10 +235,32 @@ class TestGemSource < Gem::TestCase
       1-fedcba98 |checksum:456,ruby:~> 3.4.0,platform:= x86_64-linux
     INFO
 
-    specs = @source.load_specs(:latest)
+    specs = @source.decode_content_addressable_tuples(@source.load_specs(:latest))
 
     assert_equal %w[a-1-abcdef12 a-1-fedcba98], specs.map(&:full_name).sort
     assert_equal %w[3.3 3.4], specs.map(&:ruby_abi).sort
+  end
+
+  def test_decode_content_addressable_tuples_latest_groups_by_gem_name_before_platform
+    versions_body = <<~VERSIONS
+      created_at: 2026-01-01T00:00:00Z
+      ---
+      aa 7.1-aaaa1111 0000
+      ab 1.5-bbbb2222 0000
+      ac 6.4-cccc3333 0000
+      ad 1.16-dddd4444 0000
+    VERSIONS
+    versions_response = util_compact_index_response(versions_body)
+    versions_response.uri = Gem::URI("#{@gem_repo}versions")
+    @fetcher.data["#{@gem_repo}versions"] = versions_response
+    @fetcher.data["#{@gem_repo}info/aa"] = util_compact_index_response("---\n7.1-aaaa1111 |checksum:111,ruby:~> 3.3.0,platform:= x86_64-linux\n")
+    @fetcher.data["#{@gem_repo}info/ab"] = util_compact_index_response("---\n1.5-bbbb2222 |checksum:222,ruby:~> 3.3.0,platform:= x86_64-linux\n")
+    @fetcher.data["#{@gem_repo}info/ac"] = util_compact_index_response("---\n6.4-cccc3333 |checksum:333,ruby:~> 3.3.0,platform:= x86_64-linux\n")
+    @fetcher.data["#{@gem_repo}info/ad"] = util_compact_index_response("---\n1.16-dddd4444 |checksum:444,ruby:~> 3.3.0,platform:= x86_64-linux\n")
+
+    specs = @source.decode_content_addressable_tuples(@source.load_specs(:released), latest: true)
+
+    assert_equal %w[aa-7.1-aaaa1111 ab-1.5-bbbb2222 ac-6.4-cccc3333 ad-1.16-dddd4444], specs.map(&:full_name).sort
   end
 
   def test_load_specs_compact_index_latest_per_platform


### PR DESCRIPTION
## What

Addresses: https://github.com/ruby/rubygems/issues/9729

Update remote RubyGems CLI output so content-addressable / skinny gems are displayed using real gem metadata instead of the content-address hash.

This PR covers:

- `gem list -r`
- `gem search -r`
- `gem info -r`

For compact `gem list` / `gem search` output, skinny metadata is formatted with these readability rules:

- different gem versions are shown on separate lines
- different platforms are shown on separate lines
- multiple Ruby ABIs for the same version + platform stay on the same line
- when Ruby ABI metadata is shown, both `Platform:` and `Ruby ABI:` are labeled
<details>
<summary>Example output shapes:</summary>

Same version + same platform + one Ruby ABI:

```text
a (1 Platform: x86_64-linux, Ruby ABI: 3.3)
```

Same version + same platform + multiple Ruby ABIs:

```text
a (1 Platform: x86_64-linux, Ruby ABI: 3.3, 3.4)
```

Same version + multiple platforms:

```text
a (1 Platform: x86_64-linux, Ruby ABI: 3.3
   1 Platform: x86_64-linux-musl, Ruby ABI: 3.4)
```

Multiple versions:

```text
a (3 Platform: arm64-darwin, Ruby ABI: 3.4
   2 Platform: x86_64-linux, Ruby ABI: 3.4
   1 Platform: x86_64-linux, Ruby ABI: 3.3)
```

Multiple versions + multiple platforms + multiple Ruby ABIs:

```text
a (2 Platform: arm64-darwin, Ruby ABI: 3.5
   2 Platform: x86_64-linux, Ruby ABI: 3.4
   1 Platform: arm64-darwin, Ruby ABI: 3.4
   1 Platform: x86_64-linux, Ruby ABI: 3.3, 3.4)
```

Fat/platform binary without Ruby ABI metadata:

```text
a (1 x86_64-linux)
```
</details>

## Why

Skinny gems allow multiple binary gems to exist for the same gem name, version, and platform, split by Ruby ABI.

For example:

```text
my_gem 1.0.0 x86_64-linux Ruby ABI: 3.3
my_gem 1.0.0 x86_64-linux Ruby ABI: 3.4
```

Those variants cannot both use the traditional filename suffix:

```text
my_gem-1.0.0-x86_64-linux.gem
```

So content-addressable gems use a hash/token in the version/platform slot:

```text
my_gem-1.0.0-abcdef12.gem
my_gem-1.0.0-fedcba98.gem
```

That hash is useful internally, but it is not meaningful to users. Users need to know which platform and Ruby ABI a gem supports, not its content-address token.

This PR makes the remote query CLI commands decode that metadata and display the useful information.

## Tophat

<details>
<summary>Manual tophat setup and instructions</summary>

Run this from the repo root. It starts a tiny local compact-index server and checks the main skinny/CA display shapes:

- same version + same platform + multiple Ruby ABIs stays on one line
- same version + multiple platforms splits by platform
- multiple versions split by version
- multiple versions + multiple platforms + multiple Ruby ABIs keeps Ruby ABI lists grouped per version/platform
- fat/platform binaries with multiple platforms show the version once
- mixed content-addressable and fat/platform versions display together correctly
- `gem info -r` groups Ruby ABI details under `Platforms:`

```sh
TMPDIR_CA=$(mktemp -d)
GEMHOME_CA=$(mktemp -d)
PORT_CA=$(ruby -rsocket -e 's = TCPServer.new("127.0.0.1", 0); print s.addr[1]; s.close')
MARSHAL_VERSION=$(ruby --disable-gems -Ilib -e 'require "rubygems"; print Gem.marshal_version')
SERVER_PID=""
trap 'if [ -n "${SERVER_PID}" ] && kill -0 "${SERVER_PID}" 2>/dev/null; then kill "${SERVER_PID}" 2>/dev/null || true; wait "${SERVER_PID}" 2>/dev/null || true; fi; rm -rf "$TMPDIR_CA" "$GEMHOME_CA"' EXIT

mkdir -p "$TMPDIR_CA/info" "$TMPDIR_CA/quick/Marshal.$MARSHAL_VERSION"

cat > "$TMPDIR_CA/versions" <<'VERSIONS'
created_at: 2026-01-01T00:00:00Z
---
a 1-abcdef12,1-fedcba98 0000
b 1-abcdef12,1-fedcba98 0000
c 1-abcdef12,2-fedcba98,3-12345678 0000
d 1-aaaa1111,1-bbbb2222,1-cccc3333,2-dddd4444,2-eeee5555 0000
e 1-x86_64-linux,1-arm64-darwin 0000
m 1-x86_64-linux,2-abcdef12,3-fedcba98 0000
VERSIONS

cat > "$TMPDIR_CA/info/a" <<'INFO'
---
1-abcdef12 |checksum:123,ruby:~> 3.3.0,platform:= x86_64-linux
1-fedcba98 |checksum:456,ruby:~> 3.4.0,platform:= x86_64-linux
INFO

cat > "$TMPDIR_CA/info/b" <<'INFO'
---
1-abcdef12 |checksum:123,ruby:~> 3.3.0,platform:= x86_64-linux
1-fedcba98 |checksum:456,ruby:~> 3.4.0,platform:= x86_64-linux-musl
INFO

cat > "$TMPDIR_CA/info/c" <<'INFO'
---
1-abcdef12 |checksum:123,ruby:~> 3.3.0,platform:= x86_64-linux
2-fedcba98 |checksum:456,ruby:~> 3.4.0,platform:= x86_64-linux
3-12345678 |checksum:789,ruby:~> 3.4.0,platform:= arm64-darwin
INFO

cat > "$TMPDIR_CA/info/d" <<'INFO'
---
1-aaaa1111 |checksum:111,ruby:~> 3.3.0,platform:= x86_64-linux
1-bbbb2222 |checksum:222,ruby:~> 3.4.0,platform:= x86_64-linux
1-cccc3333 |checksum:333,ruby:~> 3.4.0,platform:= arm64-darwin
2-dddd4444 |checksum:444,ruby:~> 3.4.0,platform:= x86_64-linux
2-eeee5555 |checksum:555,ruby:~> 3.5.0,platform:= arm64-darwin
INFO

cat > "$TMPDIR_CA/info/m" <<'INFO'
---
2-abcdef12 |checksum:123,ruby:~> 3.3.0,platform:= x86_64-linux
3-fedcba98 |checksum:456,ruby:~> 3.4.0,platform:= arm64-darwin
INFO

ruby --disable-gems -Ilib -rzlib -e 'require "rubygems"; address = ARGV.fetch(0); abi = ARGV.fetch(1); spec = Gem::Specification.new("a", "1"); spec.platform = "x86_64-linux"; spec.content_address = address; spec.summary = "manual tophat summary for ruby #{abi}"; spec.homepage = "http://example.com"; spec.authors = ["Tophat User"]; print Zlib::Deflate.deflate(Marshal.dump(spec))' abcdef12 3.3 > "$TMPDIR_CA/quick/Marshal.$MARSHAL_VERSION/a-1-abcdef12.gemspec.rz"

ruby --disable-gems -Ilib -rzlib -e 'require "rubygems"; address = ARGV.fetch(0); abi = ARGV.fetch(1); spec = Gem::Specification.new("a", "1"); spec.platform = "x86_64-linux"; spec.content_address = address; spec.summary = "manual tophat summary for ruby #{abi}"; spec.homepage = "http://example.com"; spec.authors = ["Tophat User"]; print Zlib::Deflate.deflate(Marshal.dump(spec))' fedcba98 3.4 > "$TMPDIR_CA/quick/Marshal.$MARSHAL_VERSION/a-1-fedcba98.gemspec.rz"

python3 -m http.server "$PORT_CA" --bind 127.0.0.1 --directory "$TMPDIR_CA" >/tmp/rubygems-ca-tophat.log 2>&1 &
SERVER_PID=$!
sleep 0.5

SOURCE_CA="http://127.0.0.1:$PORT_CA"
export GEM_HOME="$GEMHOME_CA"
export GEM_PATH="$GEMHOME_CA"

echo "== same version + same platform + multiple Ruby ABIs =="
ruby --disable-gems -Ilib exe/gem list a -r --clear-sources --source "$SOURCE_CA"
ruby --disable-gems -Ilib exe/gem search a -r --clear-sources --source "$SOURCE_CA"
ruby --disable-gems -Ilib exe/gem info a -r --clear-sources --source "$SOURCE_CA"

echo
echo "== same version + multiple platforms =="
ruby --disable-gems -Ilib exe/gem list b -r --clear-sources --source "$SOURCE_CA"

echo
echo "== multiple versions =="
ruby --disable-gems -Ilib exe/gem list c -r --all --clear-sources --source "$SOURCE_CA"

echo
echo "== multiple versions + multiple platforms + multiple Ruby ABIs =="
ruby --disable-gems -Ilib exe/gem list d -r --all --clear-sources --source "$SOURCE_CA"

echo
echo "== fat/platform binary with multiple platforms =="
ruby --disable-gems -Ilib exe/gem list e -r --clear-sources --source "$SOURCE_CA"

echo
echo "== mixed content-addressable and fat/platform versions =="
ruby --disable-gems -Ilib exe/gem list m -r --all --clear-sources --source "$SOURCE_CA"
ruby --disable-gems -Ilib exe/gem search m -r --all --clear-sources --source "$SOURCE_CA"
```

</details>

<details>
<summary>Manual tophat output</summary>

```text
== same version + same platform + multiple Ruby ABIs ==
a (1 Platform: x86_64-linux, Ruby ABI: 3.3, 3.4)
a (1 Platform: x86_64-linux, Ruby ABI: 3.3, 3.4)
a (1)
    Platforms:
        x86_64-linux Ruby ABI: 3.3, 3.4
    Author: Tophat User
    Homepage: http://example.com

    manual tophat summary for ruby 3.3

== same version + multiple platforms ==
b (1 Platform: x86_64-linux, Ruby ABI: 3.3
   1 Platform: x86_64-linux-musl, Ruby ABI: 3.4)

== multiple versions ==
c (3 Platform: arm64-darwin, Ruby ABI: 3.4
   2 Platform: x86_64-linux, Ruby ABI: 3.4
   1 Platform: x86_64-linux, Ruby ABI: 3.3)

== multiple versions + multiple platforms + multiple Ruby ABIs ==
d (2 Platform: arm64-darwin, Ruby ABI: 3.5
   2 Platform: x86_64-linux, Ruby ABI: 3.4
   1 Platform: arm64-darwin, Ruby ABI: 3.4
   1 Platform: x86_64-linux, Ruby ABI: 3.3, 3.4)

== fat/platform binary with multiple platforms ==
e (1 arm64-darwin x86_64-linux)
== mixed content-addressable and fat/platform versions ==
m (3 Platform: arm64-darwin, Ruby ABI: 3.4
   2 Platform: x86_64-linux, Ruby ABI: 3.3
   1 Platform: x86_64-linux)
m (3 Platform: arm64-darwin, Ruby ABI: 3.4
   2 Platform: x86_64-linux, Ruby ABI: 3.3
   1 Platform: x86_64-linux)
```

The content-address hashes (`abcdef12`, `fedcba98`, etc.) should not be displayed in CLI output. For compact `list` / `search` output, different versions and different platforms are split onto separate lines, while multiple `Ruby ABI:` values for the same version/platform stay grouped on one line.

</details>






