### PR TITLE
Allow gem yank to select CA gems by Ruby ABI

### DIFF
--- a/lib/rubygems/commands/yank_command.rb
+++ b/lib/rubygems/commands/yank_command.rb
@@ -25,7 +25,7 @@ data you will need to change them immediately and yank your gem.
   end
 
   def usage # :nodoc:
-    "#{program_name} -v VERSION [-p PLATFORM] [--key KEY_NAME] [--host HOST] GEM"
+    "#{program_name} -v VERSION [-p PLATFORM] [--ruby-abi RUBY_ABI] [--key KEY_NAME] [--host HOST] GEM"
   end
 
   def initialize
@@ -34,6 +34,12 @@ data you will need to change them immediately and yank your gem.
     add_version_option("remove")
     add_platform_option("remove")
     add_otp_option
+
+    add_option("--ruby-abi RUBY_ABI",
+               "Yank a content-addressable gem for a specific Ruby ABI") do |value, options|
+      validate_ruby_abi(value)
+      options[:ruby_abi] = value
+    end
 
     add_option("--host HOST",
                "Yank from another gemcutter-compatible host",
@@ -50,20 +56,21 @@ data you will need to change them immediately and yank your gem.
 
     sign_in @host, scope: get_yank_scope
 
-    version   = get_version_from_requirements(options[:version])
-    platform  = get_platform_from_requirements(options)
+    version  = get_version_from_requirements(options[:version])
+    platform = get_platform_from_requirements(options)
+    ruby_abi = options[:ruby_abi]
 
     if version
-      yank_gem(version, platform)
+      yank_gem(version, platform, ruby_abi)
     else
       say "A version argument is required: #{usage}"
       terminate_interaction
     end
   end
 
-  def yank_gem(version, platform)
+  def yank_gem(version, platform, ruby_abi)
     say "Yanking gem from #{host}..."
-    args = [:delete, version, platform, "api/v1/gems/yank"]
+    args = [:delete, version, platform, ruby_abi, "api/v1/gems/yank"]
     response = yank_api_request(*args)
 
     say response.body
@@ -71,7 +78,7 @@ data you will need to change them immediately and yank your gem.
 
   private
 
-  def yank_api_request(method, version, platform, api)
+  def yank_api_request(method, version, platform, ruby_abi, api)
     name = get_one_gem_name
     response = rubygems_api_request(method, api, host, scope: get_yank_scope) do |request|
       request.add_field("Authorization", api_key)
@@ -81,10 +88,17 @@ data you will need to change them immediately and yank your gem.
         "version" => version,
       }
       data["platform"] = platform if platform
+      data["ruby_abi"] = ruby_abi if ruby_abi
 
       request.set_form_data data
     end
     response
+  end
+
+  def validate_ruby_abi(ruby_abi)
+    return if /\A\d+\.\d+\z/.match?(ruby_abi)
+
+    raise Gem::OptionParser::InvalidArgument, "Ruby ABI must be in X.Y format"
   end
 
   def get_version_from_requirements(requirements)

--- a/test/rubygems/test_gem_commands_yank_command.rb
+++ b/test/rubygems/test_gem_commands_yank_command.rb
@@ -27,21 +27,30 @@ class TestGemCommandsYankCommand < Gem::TestCase
   end
 
   def test_handle_options
-    @cmd.handle_options %w[a --version 1.0 --platform x86-darwin -k KEY --host HOST]
+    @cmd.handle_options %w[a --version 1.0 --platform x86-darwin --ruby-abi 3.4 -k KEY --host HOST]
 
     assert_equal %w[a],        @cmd.options[:args]
     assert_equal :KEY,         @cmd.options[:key]
     assert_equal "HOST",       @cmd.options[:host]
     assert_nil                 @cmd.options[:platform]
+    assert_equal "3.4",        @cmd.options[:ruby_abi]
     assert_equal req("= 1.0"), @cmd.options[:version]
   end
 
   def test_handle_options_missing_argument
-    %w[-v --version -p --platform].each do |option|
+    %w[-v --version -p --platform --ruby-abi].each do |option|
       assert_raise Gem::OptionParser::MissingArgument do
         @cmd.handle_options %W[a #{option}]
       end
     end
+  end
+
+  def test_handle_options_invalid_ruby_abi
+    e = assert_raise Gem::OptionParser::InvalidArgument do
+      @cmd.handle_options %w[a --version 1.0 --ruby-abi 3]
+    end
+
+    assert_match(/Ruby ABI must be in X.Y format/, e.message)
   end
 
   def test_execute
@@ -65,6 +74,51 @@ class TestGemCommandsYankCommand < Gem::TestCase
 
     assert_equal "key", @fetcher.last_request["Authorization"]
 
+    assert_equal [yank_uri], @fetcher.paths
+  end
+
+  def test_execute_with_ruby_abi_sends_platform_and_ruby_abi_to_yank_api
+    original_platforms = Gem.platforms.dup
+    yank_uri = "http://example/api/v1/gems/yank"
+    @fetcher.data[yank_uri] = HTTPResponseFactory.create(body: "Successfully yanked", code: 200, msg: "OK")
+
+    @cmd.options[:args] = %w[a]
+    @cmd.options[:version] = req("= 1.0")
+    @cmd.options[:ruby_abi] = "3.4"
+    Gem.platforms = [Gem::Platform::RUBY, Gem::Platform.new("x86_64-linux")]
+    @cmd.options[:added_platform] = true
+
+    use_ui @ui do
+      @cmd.execute
+    end
+
+    body = @fetcher.last_request.body.split("&").sort
+    assert_equal %w[gem_name=a platform=x86_64-linux ruby_abi=3.4 version=1.0], body
+    assert_match(/Successfully yanked/, @ui.output)
+    assert_equal [yank_uri], @fetcher.paths
+  ensure
+    Gem.platforms = original_platforms
+  end
+
+  def test_execute_with_ruby_abi_without_platform_sends_ruby_abi_to_yank_api
+    yank_uri = "http://example/api/v1/gems/yank"
+    @fetcher.data[yank_uri] = HTTPResponseFactory.create(
+      body: "The platform param is required when ruby_abi is specified.",
+      code: 400,
+      msg: "Bad Request"
+    )
+
+    @cmd.options[:args] = %w[a]
+    @cmd.options[:version] = req("= 1.0")
+    @cmd.options[:ruby_abi] = "3.4"
+
+    use_ui @ui do
+      @cmd.execute
+    end
+
+    body = @fetcher.last_request.body.split("&").sort
+    assert_equal %w[gem_name=a ruby_abi=3.4 version=1.0], body
+    assert_match(/The platform param is required when ruby_abi is specified/, @ui.output)
     assert_equal [yank_uri], @fetcher.paths
   end
 


### PR DESCRIPTION
## What

Addresses: https://github.com/ruby/rubygems/issues/9729

Add `--ruby-abi` support to `gem yank` so maintainers can yank a content-addressable / skinny gem by real metadata instead of by hash.

When `--ruby-abi` is provided, `gem yank` sends the requested Ruby ABI to the yank API as `ruby_abi`, alongside the existing `gem_name`, `version`, and optional `platform` params. The server-side deletions controller is responsible for resolving that user-facing selector to the matching content-addressable variant.

This matches the server-side yank/deletions API shape:

| Selector | Target |
|---|---|
| no `platform`, no `ruby_abi` | source/ruby gem |
| `platform` only | fat/platform gem |
| `platform` + `ruby_abi` | skinny/content-addressable gem |
| `ruby_abi` without `platform` | server returns an error |

Existing yank behavior for source gems and fat binaries is unchanged when `--ruby-abi` is not used.

## Why

Skinny gems can have multiple pushed variants with the same name, version, and platform, split by Ruby ABI:

```text
demo 0.1.0 arm64-darwin ruby-abi:3.3
demo 0.1.0 arm64-darwin ruby-abi:3.4
```

Internally those variants are identified by content-address tokens like `abcdef12` / `fedcba98`, but maintainers should not need to manually map those hashes back to platform/Ruby ABI metadata before yanking a bad release.

With this PR, maintainers can run:

```sh
gem yank demo -v 0.1.0 --platform arm64-darwin --ruby-abi 3.4
```

and RubyGems sends the user-facing selector to the yank API:

```text
gem_name=demo&version=0.1.0&platform=arm64-darwin&ruby_abi=3.4
```

The server then resolves and yanks the correct skinny variant.

## Tophat
<details>
<summary>Manual tophat script</summary>

```sh
TMPDIR_CA=$(mktemp -d)
GEMHOME_CA=$(mktemp -d)
PORT_CA=$(ruby -rsocket -e 's = TCPServer.new("127.0.0.1", 0); print s.addr[1]; s.close')
SERVER_PID=""
trap 'if [ -n "${SERVER_PID}" ] && kill -0 "${SERVER_PID}" 2>/dev/null; then kill "${SERVER_PID}" 2>/dev/null || true; wait "${SERVER_PID}" 2>/dev/null || true; fi; rm -rf "$TMPDIR_CA" "$GEMHOME_CA"' EXIT

cat > "$TMPDIR_CA/yank_server.py" <<'PY'
from http.server import BaseHTTPRequestHandler, HTTPServer
from urllib.parse import parse_qs
import sys

class Handler(BaseHTTPRequestHandler):
    def do_DELETE(self):
        length = int(self.headers.get("Content-Length", 0))
        body = self.rfile.read(length).decode()
        params = parse_qs(body, keep_blank_values=True)
        flat = {key: values[0] for key, values in params.items()}

        print(f"DELETE {self.path}", flush=True)
        print(body, flush=True)

        if "ruby_abi" in flat and "platform" not in flat:
            self.send_response(400)
            self.end_headers()
            self.wfile.write(b"The platform param is required when ruby_abi is specified.")
            return

        self.send_response(200)
        self.end_headers()
        self.wfile.write(b"Successfully yanked")

    def log_message(self, format, *args):
        print(format % args, flush=True)

server = HTTPServer(("127.0.0.1", int(sys.argv[1])), Handler)
server.serve_forever()
PY

python3 "$TMPDIR_CA/yank_server.py" "$PORT_CA" > "$TMPDIR_CA/server.log" 2>&1 &
SERVER_PID=$!
sleep 0.5

SOURCE_CA="http://127.0.0.1:$PORT_CA"
export GEM_HOME="$GEMHOME_CA"
export GEM_PATH="$GEMHOME_CA"
export GEM_HOST_API_KEY="dummy-key"

ruby --disable-gems -Ilib exe/gem yank demo \
  -v 0.1.0 \
  --host "$SOURCE_CA"

ruby --disable-gems -Ilib exe/gem yank demo \
  -v 0.1.0 \
  --platform arm64-darwin \
  --host "$SOURCE_CA"

ruby --disable-gems -Ilib exe/gem yank demo \
  -v 0.1.0 \
  --platform arm64-darwin \
  --ruby-abi 3.4 \
  --host "$SOURCE_CA"

ruby --disable-gems -Ilib exe/gem yank demo \
  -v 0.1.0 \
  --ruby-abi 3.4 \
  --host "$SOURCE_CA"

echo
echo "== server log =="
cat "$TMPDIR_CA/server.log"
```

</details>

<details>
<summary>Manual tophat output</summary>

```text
You are already signed in on http://127.0.0.1:61085.
Yanking gem from http://127.0.0.1:61085...
Successfully yanked
You are already signed in on http://127.0.0.1:61085.
Yanking gem from http://127.0.0.1:61085...
Successfully yanked
You are already signed in on http://127.0.0.1:61085.
Yanking gem from http://127.0.0.1:61085...
Successfully yanked
You are already signed in on http://127.0.0.1:61085.
Yanking gem from http://127.0.0.1:61085...
The platform param is required when ruby_abi is specified.

== server log ==
DELETE /api/v1/gems/yank
gem_name=demo&version=0.1.0
"DELETE /api/v1/gems/yank HTTP/1.1" 200 -
DELETE /api/v1/gems/yank
gem_name=demo&version=0.1.0&platform=arm64-darwin
"DELETE /api/v1/gems/yank HTTP/1.1" 200 -
DELETE /api/v1/gems/yank
gem_name=demo&version=0.1.0&platform=arm64-darwin&ruby_abi=3.4
"DELETE /api/v1/gems/yank HTTP/1.1" 200 -
DELETE /api/v1/gems/yank
gem_name=demo&version=0.1.0&ruby_abi=3.4
"DELETE /api/v1/gems/yank HTTP/1.1" 400 -
```

The important checks are:

- source/ruby gem yanking sends no `platform` or `ruby_abi`
- fat/platform yanking sends `platform=arm64-darwin`
- skinny/content-addressable yanking sends `platform=arm64-darwin&ruby_abi=3.4`
- `--ruby-abi` without `--platform` is sent to the server, which can return the deletions-controller validation error
- no compact-index `/info/<gem>` lookup is needed by the client

</details>

