### PR TITLE
Skip CA metadata for unscoped remote queries

### DIFF
--- a/lib/rubygems/query_utils.rb
+++ b/lib/rubygems/query_utils.rb
@@ -149,12 +149,16 @@ module Gem::QueryUtils
     spec_tuples = if name.nil?
       fetcher.detect(specs_type) { true }
     else
-      fetcher.detect(specs_type) do |name_tuple|
+      matching_tuples = fetcher.detect(specs_type) do |name_tuple|
         name === name_tuple.name && options[:version].satisfied_by?(name_tuple.version)
       end
-    end
 
-    spec_tuples = decode_content_addressable_tuples(spec_tuples, latest: specs_type == :latest)
+      if args.empty?
+        matching_tuples
+      else
+        decode_content_addressable_tuples(matching_tuples, latest: specs_type == :latest)
+      end
+    end
 
     output_query_results(spec_tuples)
   end

--- a/test/rubygems/test_gem_commands_info_command.rb
+++ b/test/rubygems/test_gem_commands_info_command.rb
@@ -42,6 +42,49 @@ class TestGemCommandsInfoCommand < Gem::TestCase
     assert_match "", @ui.error
   end
 
+  def test_execute_remote_unscoped_content_addressable_gems_do_not_fetch_metadata
+    spec_fetcher {}
+
+    spec_a = util_spec "a", "1" do |s|
+      s.platform = "x86_64-linux"
+      s.summary = "summary a"
+      s.homepage = "http://example.com"
+      s.authors = ["A User"]
+    end
+    spec_a.content_address = "abcdef12"
+
+    spec_b = util_spec "b", "1" do |s|
+      s.platform = "arm64-darwin"
+      s.summary = "summary b"
+      s.homepage = "http://example.com"
+      s.authors = ["B User"]
+    end
+    spec_b.content_address = "fedcba98"
+
+    versions_body = +"created_at: 2026-01-01T00:00:00Z\n---\na 1-abcdef12 0000\nb 1-fedcba98 0000\n"
+    versions_response = util_compact_index_response(versions_body)
+    versions_response.uri = Gem::URI("#{@gem_repo}versions")
+    @fetcher.data["#{@gem_repo}versions"] = versions_response
+    @fetcher.data["#{@gem_repo}info/a"] = util_compact_index_response("---\n1-abcdef12 |checksum:123,ruby:~> 3.3.0,platform:= x86_64-linux\n")
+    @fetcher.data["#{@gem_repo}info/b"] = util_compact_index_response("---\n1-fedcba98 |checksum:456,ruby:~> 3.4.0,platform:= arm64-darwin\n")
+    path = "#{@gem_repo}quick/Marshal.#{Gem.marshal_version}/a-1-abcdef12.gemspec.rz"
+    @fetcher.data[path] = Zlib::Deflate.deflate(Marshal.dump(spec_a))
+    path = "#{@gem_repo}quick/Marshal.#{Gem.marshal_version}/b-1-fedcba98.gemspec.rz"
+    @fetcher.data[path] = Zlib::Deflate.deflate(Marshal.dump(spec_b))
+    Gem::SpecFetcher.fetcher = nil
+
+    @cmd.handle_options %w[--remote]
+
+    use_ui @ui do
+      @cmd.execute
+    end
+
+    assert_include @ui.output, "a (1)"
+    assert_include @ui.output, "b (1)"
+    refute_match "Ruby ABI", @ui.output
+    refute @fetcher.requests.any? {|req| req.path.start_with?("/info/") }
+  end
+
   def test_execute_remote_content_addressable_gem_displays_real_platform_and_ruby_abi
     spec_fetcher {}
 

--- a/test/rubygems/test_gem_commands_list_command.rb
+++ b/test/rubygems/test_gem_commands_list_command.rb
@@ -31,6 +31,54 @@ class TestGemCommandsListCommand < Gem::TestCase
     assert_equal "", @ui.error
   end
 
+  def test_execute_remote_unscoped_content_addressable_gems_do_not_fetch_metadata
+    spec_fetcher {}
+
+    versions_body = +"created_at: 2026-01-01T00:00:00Z\n---\na 1-abcdef12 0000\nb 1-fedcba98 0000\n"
+    versions_response = util_compact_index_response(versions_body)
+    versions_response.uri = Gem::URI("#{@gem_repo}versions")
+    @fetcher.data["#{@gem_repo}versions"] = versions_response
+    @fetcher.data["#{@gem_repo}info/a"] = util_compact_index_response("---\n1-abcdef12 |checksum:123,ruby:~> 3.3.0,platform:= x86_64-linux\n")
+    @fetcher.data["#{@gem_repo}info/b"] = util_compact_index_response("---\n1-fedcba98 |checksum:456,ruby:~> 3.4.0,platform:= arm64-darwin\n")
+    Gem::SpecFetcher.fetcher = nil
+
+    @cmd.handle_options %w[--remote]
+
+    use_ui @ui do
+      @cmd.execute
+    end
+
+    assert_include @ui.output, "a (1 abcdef12)"
+    assert_include @ui.output, "b (1 fedcba98)"
+    refute_match "Ruby ABI", @ui.output
+    refute @fetcher.requests.any? {|req| req.path.start_with?("/info/") }
+  end
+
+  def test_execute_remote_unscoped_all_content_addressable_gems_do_not_fetch_metadata
+    spec_fetcher {}
+
+    versions_body = +"created_at: 2026-01-01T00:00:00Z\n---\na 1-abcdef12,2-fedcba98 0000\n"
+    versions_response = util_compact_index_response(versions_body)
+    versions_response.uri = Gem::URI("#{@gem_repo}versions")
+    @fetcher.data["#{@gem_repo}versions"] = versions_response
+    @fetcher.data["#{@gem_repo}info/a"] = util_compact_index_response(<<~INFO)
+      ---
+      1-abcdef12 |checksum:123,ruby:~> 3.3.0,platform:= x86_64-linux
+      2-fedcba98 |checksum:456,ruby:~> 3.4.0,platform:= arm64-darwin
+    INFO
+    Gem::SpecFetcher.fetcher = nil
+
+    @cmd.handle_options %w[--remote --all]
+
+    use_ui @ui do
+      @cmd.execute
+    end
+
+    assert_include @ui.output, "a (2 fedcba98, 1 abcdef12)"
+    refute_match "Ruby ABI", @ui.output
+    refute @fetcher.requests.any? {|req| req.path.start_with?("/info/") }
+  end
+
   def test_execute_remote_content_addressable_gem_displays_real_platform_and_ruby_abi
     spec_fetcher {}
 

--- a/test/rubygems/test_gem_commands_search_command.rb
+++ b/test/rubygems/test_gem_commands_search_command.rb
@@ -14,6 +14,54 @@ class TestGemCommandsSearchCommand < Gem::TestCase
     assert_equal :remote, @cmd.defaults[:domain]
   end
 
+  def test_execute_unscoped_content_addressable_gems_do_not_fetch_metadata
+    spec_fetcher {}
+
+    versions_body = +"created_at: 2026-01-01T00:00:00Z\n---\na 1-abcdef12 0000\nb 1-fedcba98 0000\n"
+    versions_response = util_compact_index_response(versions_body)
+    versions_response.uri = Gem::URI("#{@gem_repo}versions")
+    @fetcher.data["#{@gem_repo}versions"] = versions_response
+    @fetcher.data["#{@gem_repo}info/a"] = util_compact_index_response("---\n1-abcdef12 |checksum:123,ruby:~> 3.3.0,platform:= x86_64-linux\n")
+    @fetcher.data["#{@gem_repo}info/b"] = util_compact_index_response("---\n1-fedcba98 |checksum:456,ruby:~> 3.4.0,platform:= arm64-darwin\n")
+    Gem::SpecFetcher.fetcher = nil
+
+    @cmd.handle_options []
+
+    use_ui @ui do
+      @cmd.execute
+    end
+
+    assert_include @ui.output, "a (1 abcdef12)"
+    assert_include @ui.output, "b (1 fedcba98)"
+    refute_match "Ruby ABI", @ui.output
+    refute @fetcher.requests.any? {|req| req.path.start_with?("/info/") }
+  end
+
+  def test_execute_unscoped_all_content_addressable_gems_do_not_fetch_metadata
+    spec_fetcher {}
+
+    versions_body = +"created_at: 2026-01-01T00:00:00Z\n---\na 1-abcdef12,2-fedcba98 0000\n"
+    versions_response = util_compact_index_response(versions_body)
+    versions_response.uri = Gem::URI("#{@gem_repo}versions")
+    @fetcher.data["#{@gem_repo}versions"] = versions_response
+    @fetcher.data["#{@gem_repo}info/a"] = util_compact_index_response(<<~INFO)
+      ---
+      1-abcdef12 |checksum:123,ruby:~> 3.3.0,platform:= x86_64-linux
+      2-fedcba98 |checksum:456,ruby:~> 3.4.0,platform:= arm64-darwin
+    INFO
+    Gem::SpecFetcher.fetcher = nil
+
+    @cmd.handle_options %w[--all]
+
+    use_ui @ui do
+      @cmd.execute
+    end
+
+    assert_include @ui.output, "a (2 fedcba98, 1 abcdef12)"
+    refute_match "Ruby ABI", @ui.output
+    refute @fetcher.requests.any? {|req| req.path.start_with?("/info/") }
+  end
+
   def test_execute_content_addressable_gem_displays_real_platform_and_ruby_abi
     spec_fetcher {}
 


### PR DESCRIPTION
## What

- Closes: https://github.com/ruby/rubygems/issues/9729

Avoid fetching content-addressable platform/Ruby ABI metadata for unscoped remote query commands.

Unscoped commands now keep using the metadata already available from the compact index `versions` response, while scoped commands still fetch `info/<gem>` and show decoded platform/Ruby ABI output.

## Why

Commands like:

```sh
gem list -r
gem search -r
gem info -r
```

can return every remote gem. If those commands inspect CA platform/Ruby ABI metadata, they can make one `info/<gem>` request per CA gem name, which is expensive on a large index.

Scoped commands like:

```sh
gem list nokogiri -r
gem search nokogiri -r
gem info nokogiri -r
```

are still bounded by the user's query, so they continue to fetch and display the decoded CA metadata.

## Tophat

<details>
<summary>Instructions</summary>

```sh
TMPDIR_CA=$(mktemp -d)
GEMHOME_CA=$(mktemp -d)
LOG=$(mktemp)
PORT_CA=$(ruby -rsocket -e 's = TCPServer.new("127.0.0.1", 0); print s.addr[1]; s.close')
MARSHAL_VERSION=$(ruby --disable-gems -Ilib -e 'require "rubygems"; print Gem.marshal_version')
mkdir -p "$TMPDIR_CA/info" "$TMPDIR_CA/quick/Marshal.$MARSHAL_VERSION"

cat > "$TMPDIR_CA/versions" <<'VERSIONS'
created_at: 2026-01-01T00:00:00Z
---
skinny 1-abcdef12 0000
fat 1-x86_64-linux,1-arm64-darwin 0000
mixed 1-x86_64-linux,2-fedcba98 0000
VERSIONS

cat > "$TMPDIR_CA/info/skinny" <<'INFO'
---
1-abcdef12 |checksum:123,ruby:~> 3.3.0,platform:= x86_64-linux
INFO

cat > "$TMPDIR_CA/info/mixed" <<'INFO'
---
2-fedcba98 |checksum:456,ruby:~> 3.4.0,platform:= arm64-darwin
INFO

make_spec() {
  local name=$1 version=$2 platform=$3 address=$4
  local filename
  if [ -n "$address" ]; then
    filename="$name-$version-$address.gemspec.rz"
  elif [ "$platform" = "ruby" ]; then
    filename="$name-$version.gemspec.rz"
  else
    filename="$name-$version-$platform.gemspec.rz"
  fi

  ruby --disable-gems -Ilib -rzlib -e 'require "rubygems"; name, version, platform, address = ARGV; spec = Gem::Specification.new(name, version); spec.platform = platform; spec.content_address = address unless address.empty?; spec.summary = "summary for #{name}"; spec.homepage = "http://example.com/#{name}"; spec.authors = ["Tophat User"]; print Zlib::Deflate.deflate(Marshal.dump(spec))' "$name" "$version" "$platform" "$address" > "$TMPDIR_CA/quick/Marshal.$MARSHAL_VERSION/$filename"
}

make_spec skinny 1 x86_64-linux abcdef12
make_spec fat 1 x86_64-linux ""
make_spec fat 1 arm64-darwin ""
make_spec mixed 1 x86_64-linux ""
make_spec mixed 2 arm64-darwin fedcba98

python3 -m http.server "$PORT_CA" --bind 127.0.0.1 --directory "$TMPDIR_CA" >"$LOG" 2>&1 &
SERVER_PID=$!
trap 'kill "$SERVER_PID" 2>/dev/null || true; rm -rf "$TMPDIR_CA" "$GEMHOME_CA" "$LOG"' EXIT
sleep 0.5

SOURCE_CA="http://127.0.0.1:$PORT_CA"
export GEM_HOME="$GEMHOME_CA" GEM_PATH="$GEMHOME_CA"

ruby --disable-gems -Ilib exe/gem list -r --clear-sources --source "$SOURCE_CA"
ruby --disable-gems -Ilib exe/gem search -r --clear-sources --source "$SOURCE_CA"
ruby --disable-gems -Ilib exe/gem info -r --clear-sources --source "$SOURCE_CA"
ruby --disable-gems -Ilib exe/gem list skinny -r --clear-sources --source "$SOURCE_CA"
ruby --disable-gems -Ilib exe/gem search skinny -r --clear-sources --source "$SOURCE_CA"
ruby --disable-gems -Ilib exe/gem info skinny -r --clear-sources --source "$SOURCE_CA"
ruby --disable-gems -Ilib exe/gem list mixed -r --all --clear-sources --source "$SOURCE_CA"
ruby --disable-gems -Ilib exe/gem search mixed -r --all --clear-sources --source "$SOURCE_CA"
ruby --disable-gems -Ilib exe/gem info mixed -r --all --clear-sources --source "$SOURCE_CA"
grep 'GET /info/' "$LOG" || true
```

</details>
<details>
<summary>Output:</summary>

```text
== UNSCOPED list: skinny + fat + mixed ==
fat (1 arm64-darwin x86_64-linux)
mixed (2 fedcba98, 1 x86_64-linux)
skinny (1 abcdef12)

== UNSCOPED search: skinny + fat + mixed ==
fat (1 arm64-darwin x86_64-linux)
mixed (2 fedcba98, 1 x86_64-linux)
skinny (1 abcdef12)

== UNSCOPED info: skinny + fat + mixed ==
fat (1)
    Platforms: arm64-darwin, x86_64-linux
    Author: Tophat User
    Homepage: http://example.com/fat

    summary for fat

mixed (2, 1)
    Platforms:
        1: x86_64-linux
        2: fedcba98
    Author: Tophat User
    Homepage: http://example.com/mixed

    summary for mixed

skinny (1)
    Platform: abcdef12
    Author: Tophat User
    Homepage: http://example.com/skinny

    summary for skinny

== SCOPED list skinny ==
skinny (1 Platform: x86_64-linux, Ruby ABI: 3.3)

== SCOPED search skinny ==
skinny (1 Platform: x86_64-linux, Ruby ABI: 3.3)

== SCOPED info skinny ==
skinny (1)
    Platforms:
        x86_64-linux Ruby ABI: 3.3
    Author: Tophat User
    Homepage: http://example.com/skinny

    summary for skinny

== SCOPED list mixed --all ==
mixed (2 Platform: arm64-darwin, Ruby ABI: 3.4
       1 Platform: x86_64-linux)

== SCOPED search mixed --all ==
mixed (2 Platform: arm64-darwin, Ruby ABI: 3.4
       1 Platform: x86_64-linux)

== SCOPED info mixed --all ==
mixed (2, 1)
    Platforms:
        1: x86_64-linux
        2: arm64-darwin Ruby ABI: 3.4
    Author: Tophat User
    Homepage: http://example.com/mixed

    summary for mixed

== info/<gem> request summary ==
GET /info/skinny
GET /info/skinny
GET /info/skinny
GET /info/mixed
GET /info/mixed
GET /info/mixed
```
</details>